### PR TITLE
Added support for equity vol moneyness surfaces.

### DIFF
--- a/OREData/ored/configuration/equityvolcurveconfig.cpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.cpp
@@ -19,6 +19,7 @@
 #include <ored/configuration/equityvolcurveconfig.hpp>
 #include <ored/utilities/parsers.hpp>
 #include <ored/utilities/to_string.hpp>
+#include <ored/utilities/log.hpp>
 #include <ql/errors.hpp>
 
 using ore::data::XMLUtils;
@@ -29,9 +30,11 @@ namespace data {
 EquityVolatilityCurveConfig::EquityVolatilityCurveConfig(const string& curveID, const string& curveDescription,
                                                          const string& currency,
                                                          const boost::shared_ptr<VolatilityConfig>& volatilityConfig,
-                                                         const string& dayCounter, const string& calendar)
+                                                         const string& dayCounter, const string& calendar,
+                                                         const std::string& equityCurveId,
+                                                         const std::string& yieldCurveId)
     : CurveConfig(curveID, curveDescription), ccy_(currency), volatilityConfig_(volatilityConfig),
-      dayCounter_(dayCounter), calendar_(calendar) {
+      dayCounter_(dayCounter), calendar_(calendar), equityCurveId_(equityCurveId), yieldCurveId_(yieldCurveId) {
     populateQuotes();
 }
 
@@ -121,28 +124,39 @@ void EquityVolatilityCurveConfig::fromXML(XMLNode* node) {
     } else if (dim == "") {
         XMLNode* n;
         if ((n = XMLUtils::getChildNode(node, "Constant"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type ConstantVolatilityConfig");
             volatilityConfig_ = boost::make_shared<ConstantVolatilityConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "Curve"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityCurveConfig");
             volatilityConfig_ = boost::make_shared<VolatilityCurveConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "StrikeSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityStrikeSurfaceConfig");
             volatilityConfig_ = boost::make_shared<VolatilityStrikeSurfaceConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "DeltaSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityDeltaSurfaceConfig");
             QL_FAIL("DeltaSurface not currently supported for equity volatilities.");
         } else if ((n = XMLUtils::getChildNode(node, "MoneynessSurface"))) {
-            QL_FAIL("MoneynessSurface not currently supported for equity volatilities.");
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityMoneynessSurfaceConfig");
+            volatilityConfig_ = boost::make_shared<VolatilityMoneynessSurfaceConfig>();
         } else if ((n = XMLUtils::getChildNode(node, "ApoFutureSurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type VolatilityApoFutureSurfaceConfig");
             QL_FAIL("ApoFutureSurface not supported for equity volatilities.");
         } else if ((n = XMLUtils::getChildNode(node, "ProxySurface"))) {
+            DLOG("CurveId " << curveID_ << " is of volatility config type ProxySurface");
             proxySurface_ = XMLUtils::getChildValue(node, "ProxySurface", true);
         } else {
             QL_FAIL("EquityVolatility node expects one child node with name in list: Constant,"
-                    << " Curve, StrikeSurface, ProxySurface.");
+                    << " Curve, StrikeSurface, MoneynessSurface, ProxySurface.");
         }
         if (proxySurface_.empty())
             volatilityConfig_->fromXML(n);
     } else {
         QL_FAIL("Only ATM and Smile dimensions, or Volatility Config supported for EquityVolatility " << curveID_);
     }
+
+    equityCurveId_ = XMLUtils::getChildValue(node, "EquityCurveId", false);
+    yieldCurveId_ = XMLUtils::getChildValue(node, "YieldCurveId", false);
+
     populateQuotes();
 }
 
@@ -163,6 +177,10 @@ XMLNode* EquityVolatilityCurveConfig::toXML(XMLDocument& doc) {
     }
     if (calendar_ != "NullCalendar")
         XMLUtils::addChild(doc, node, "Calendar", calendar_);
+    if (!equityCurveId_.empty())
+        XMLUtils::addChild(doc, node, "EquityCurveId", equityCurveId_);
+    if (!yieldCurveId_.empty())
+        XMLUtils::addChild(doc, node, "YieldCurveId", yieldCurveId_);
 
     return node;
 }

--- a/OREData/ored/configuration/equityvolcurveconfig.hpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.hpp
@@ -50,7 +50,8 @@ public:
     //! Detailed constructor
     EquityVolatilityCurveConfig(const string& curveID, const string& curveDescription, const string& currency,
                                 const boost::shared_ptr<VolatilityConfig>& volatilityConfig,
-                                const string& dayCounter = "A365", const string& calendar = "NullCalendar");
+                                const string& dayCounter = "A365", const string& calendar = "NullCalendar",
+                                const std::string& equityCurveId = "", const std::string& yieldCurveId = "");
     //@}
 
     //! \name Serialisation
@@ -69,8 +70,9 @@ public:
     const boost::shared_ptr<VolatilityConfig>& volatilityConfig() const { return volatilityConfig_; };
     const string& proxySurface() const { return proxySurface_; }
     const string quoteStem() const;
-    void populateQuotes();
     bool isProxySurface() { return !proxySurface_.empty(); };
+    const std::string& equityCurveId() const { return equityCurveId_; };
+    const std::string& yieldCurveId() const { return yieldCurveId_; };
     //@}
 
     //! \name Setters
@@ -85,6 +87,11 @@ private:
     string dayCounter_;
     string calendar_;
     string proxySurface_;
+    std::string equityCurveId_;
+    std::string yieldCurveId_;
+
+    //! Populate CurveConfig::quotes_ with the required quotes.
+    void populateQuotes(); // Changed to private
 };
 } // namespace data
 } // namespace ore

--- a/OREData/ored/marketdata/equitycurve.cpp
+++ b/OREData/ored/marketdata/equitycurve.cpp
@@ -287,10 +287,16 @@ EquityCurve::EquityCurve(Date asof, EquityCurveSpec spec, const Loader& loader, 
                                                                                  << calls[i]->strike());
                             callDates.push_back(getDateFromDateOrPeriod(calls[i]->expiry(), asof));
                             putDates.push_back(getDateFromDateOrPeriod(puts[j]->expiry(), asof));
-                            callStrikes.push_back(parseReal(calls[i]->strike()));
-                            putStrikes.push_back(parseReal(puts[j]->strike()));
                             callPremiums.push_back(calls[i]->quote()->value());
                             putPremiums.push_back(puts[j]->quote()->value());
+
+                            // TODO: Should this always be AbsoluteStrike? 
+                            boost::shared_ptr<ore::data::AbsoluteStrike> callStrike =
+                                boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(calls[i]->strike());
+                            callStrikes.push_back(callStrike->strike());
+                            boost::shared_ptr<ore::data::AbsoluteStrike> putStrike =
+                                boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(calls[i]->strike());
+                            putStrikes.push_back(putStrike->strike());
                         }
                     }
                 }

--- a/OREData/ored/marketdata/equityvolcurve.cpp
+++ b/OREData/ored/marketdata/equityvolcurve.cpp
@@ -17,6 +17,9 @@
 */
 
 #include <algorithm>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+#include <boost/range/adaptor/indexed.hpp>
 #include <ored/marketdata/equityvolcurve.hpp>
 #include <ored/marketdata/marketdatumparser.hpp>
 #include <ored/utilities/log.hpp>
@@ -30,6 +33,7 @@
 #include <ql/time/calendars/weekendsonly.hpp>
 #include <ql/time/daycounters/actual365fixed.hpp>
 #include <qle/termstructures/blackvariancesurfacesparse.hpp>
+#include <qle/termstructures/blackvariancesurfacemoneyness.hpp>
 #include <qle/termstructures/equityblackvolsurfaceproxy.hpp>
 #include <qle/termstructures/equityoptionsurfacestripper.hpp>
 #include <qle/termstructures/optionpricesurface.hpp>
@@ -44,6 +48,7 @@ namespace data {
 
 EquityVolCurve::EquityVolCurve(Date asof, EquityVolatilityCurveSpec spec, const Loader& loader,
                                const CurveConfigurations& curveConfigs, const Handle<EquityIndex>& eqIndex,
+                               const map<string, boost::shared_ptr<YieldCurve>>& requiredYieldCurves,
                                const map<string, boost::shared_ptr<EquityCurve>>& requiredEquityCurves,
                                const map<string, boost::shared_ptr<EquityVolCurve>>& requiredEquityVolCurves) {
 
@@ -74,6 +79,13 @@ EquityVolCurve::EquityVolCurve(Date asof, EquityVolatilityCurveSpec spec, const 
                 buildVolatility(asof, config, *vcc, loader);
             } else if (auto vssc = boost::dynamic_pointer_cast<VolatilityStrikeSurfaceConfig>(vc)) {
                 buildVolatility(asof, config, *vssc, loader, eqIndex);
+            } else if (auto vmsc = boost::dynamic_pointer_cast<VolatilityMoneynessSurfaceConfig>(vc)) {
+                // Need a yield curve (if forward moneyness) and equity index (with dividend yield term structure) to
+                // create a moneyness surface.
+                MoneynessStrike::Type moneynessType = parseMoneynessType(vmsc->moneynessType());
+                bool fwdMoneyness = moneynessType == MoneynessStrike::Type::Forward;
+                populateCurves(config, requiredYieldCurves, requiredEquityCurves, fwdMoneyness);
+                buildVolatility(asof, config, *vmsc, loader);
             } else {
                 QL_FAIL("Unexpected VolatilityConfig in EquityVolatilityConfig");
             }
@@ -153,7 +165,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
         // Create the regular expression
         regex regexp(boost::replace_all_copy(vcc.quotes()[0], "*", ".*"));
 
-        // Loop over quotes and process commodity option quotes matching pattern on asof
+        // Loop over quotes and process equity option quotes matching pattern on asof
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
 
             // Go to next quote if the market data point's date does not equal our asof
@@ -186,7 +198,7 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
 
         DLOG("Have " << vcc.quotes().size() << " explicit quotes");
 
-        // Loop over quotes and process commodity option quotes that are explicitly specified in the config
+        // Loop over quotes and process equity option quotes that are explicitly specified in the config
         for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
             // Go to next quote if the market data point's date does not equal our asof
             if (md->asofDate() != asof)
@@ -273,8 +285,9 @@ void EquityVolCurve::buildVolatility(const Date& asof, const EquityVolatilityCur
 void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConfig& vc,
                                      const VolatilityStrikeSurfaceConfig& vssc, const Loader& loader,
                                      const QuantLib::Handle<EquityIndex>& eqIndex) {
-    try {
+    LOG("EquityVolCurve: start building 2-D volatility absolute strike surface");
 
+    try {
         QL_REQUIRE(vssc.expiries().size() > 0, "No expiries defined");
         QL_REQUIRE(vssc.strikes().size() > 0, "No strikes defined");
 
@@ -298,6 +311,19 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
         bool expiryRelevant = expiriesWc;
         bool quoteRelevant = true;
 
+        // If we do not have a strike wild card, we expect a list of absolute strike values
+        vector<Real> configuredStrikes;
+        if (!strikesWc) {
+            // Parse the list of absolute strikes
+            configuredStrikes = parseVectorOfValues<Real>(vssc.strikes(), &parseReal);
+            sort(configuredStrikes.begin(), configuredStrikes.end(),
+                 [](Real x, Real y) { return !close(x, y) && x < y; });
+            QL_REQUIRE(adjacent_find(configuredStrikes.begin(), configuredStrikes.end(),
+                                     [](Real x, Real y) { return close(x, y); }) == configuredStrikes.end(),
+                       "The configured strikes contain duplicates");
+            DLOG("Parsed " << configuredStrikes.size() << " unique configured absolute strikes");
+        }
+
         // We loop over all market data, looking for quotes that match the configuration
         Size callQuotesAdded = 0;
         Size putQuotesAdded = 0;
@@ -313,11 +339,18 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
                         expiryRelevant = j != vssc.expiries().end();
                     }
                     if (!strikesWc) {
-                        auto i = std::find(vssc.strikes().begin(), vssc.strikes().end(), q->strike());
-                        strikeRelevant = i != vssc.strikes().end();
+                        // Parse the list of absolute strikes
+
+                        boost::shared_ptr<ore::data::AbsoluteStrike> absStrike =
+                            boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(q->strike());
+                        auto i = std::find_if(configuredStrikes.begin(), configuredStrikes.end(),
+                                              [&absStrike](Real s) { return close(s, absStrike->strike()); });
+                        strikeRelevant = i != configuredStrikes.end();
                     } else {
                         // todo - for now we will ignore ATMF quotes in case of strike wild card. ----
-                        strikeRelevant = q->strike() != "ATMF";
+                        boost::shared_ptr<ore::data::AtmStrike> atm =
+                            boost::dynamic_pointer_cast<ore::data::AtmStrike>(q->strike());
+                        strikeRelevant = !atm; // Effectively: quote strike != "ATMF";
                     }
                     quoteRelevant = strikeRelevant && expiryRelevant;
 
@@ -329,13 +362,16 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
                         Date tmpDate = getDateFromDateOrPeriod(q->expiry(), asof, calendar_);
                         QL_REQUIRE(tmpDate > asof,
                                    "Option quote for a past date (" << ore::data::to_string(tmpDate) << ")");
+
+                        boost::shared_ptr<ore::data::AbsoluteStrike> absStrike =
+                            boost::dynamic_pointer_cast<ore::data::AbsoluteStrike>(q->strike());
                         if (q->isCall()) {
-                            callStrikes.push_back(parseReal(q->strike()));
+                            callStrikes.push_back(absStrike->strike());
                             callData.push_back(q->quote()->value());
                             callExpiries.push_back(tmpDate);
                             callQuotesAdded++;
                         } else {
-                            putStrikes.push_back(parseReal(q->strike()));
+                            putStrikes.push_back(absStrike->strike());
                             putData.push_back(q->quote()->value());
                             putExpiries.push_back(tmpDate);
                             putQuotesAdded++;
@@ -364,15 +400,15 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
                            "Call and Put quotes must match for explicitly defined surface, "
                                << callQuotesAdded << " call quotes, and " << putQuotesAdded << " put quotes");
                 DLOG("EquityVolatilityCurve " << vc.curveID() << ": Complete set of " << callQuotesAdded
-                                              << ", call and put quotes found.");
+                                              << " call and put quotes found.");
             }
         }
 
         QL_REQUIRE(callStrikes.size() == callData.size() && callData.size() == callExpiries.size(),
-                   "Quotes loaded don't produce strike,vol,expiry vectors of equal length.");
+                   "Quotes loaded don't produce strike, vol, expiry vectors of equal length.");
         QL_REQUIRE(putStrikes.size() == putData.size() && putData.size() == putExpiries.size(),
-                   "Quotes loaded don't produce strike,vol,expiry vectors of equal length.");
-        DLOG("EquityVolatilityCurve " << vc.curveID() << ": Found " << callQuotesAdded << ", call quotes and "
+                   "Quotes loaded don't produce strike, vol, expiry vectors of equal length.");
+        DLOG("EquityVolatilityCurve " << vc.curveID() << ": Found " << callQuotesAdded << " call quotes and "
                                       << putQuotesAdded << " put quotes using wildcard.");
 
         // Set the strike extrapolation which only matters if extrapolation is turned on for the whole surface.
@@ -462,9 +498,226 @@ void EquityVolCurve::buildVolatility(const Date& asof, EquityVolatilityCurveConf
         DLOG("Setting BlackVarianceSurfaceSparse extrapolation to " << to_string(vssc.extrapolation()));
         vol_->enableExtrapolation(vssc.extrapolation());
 
+        LOG("EquityVolCurve: finished building 2-D volatility absolute strike surface");
     } catch (std::exception& e) {
         QL_FAIL("equity vol curve building failed :" << e.what());
     } catch (...) {
+        QL_FAIL("equity vol curve building failed: unknown error");
+    }
+}
+
+void EquityVolCurve::buildVolatility(const QuantLib::Date& asof, EquityVolatilityCurveConfig& vc,
+                                     const VolatilityMoneynessSurfaceConfig& vmsc, const Loader& loader) {
+    LOG("EquityVolCurve: start building 2-D volatility moneyness strike surface");
+
+    try {
+        // For background to implementation, see original in 
+        // commodityvolcurve.cpp::buildVolatility() for MoneynessSurface configs
+
+        // Expiries may be configured with a wildcard or given explicitly
+        bool expWc = find(vmsc.expiries().begin(), vmsc.expiries().end(), "*") != vmsc.expiries().end();
+        bool mnyWc =
+            find(vmsc.moneynessLevels().begin(), vmsc.moneynessLevels().end(), "*") != vmsc.moneynessLevels().end();
+        if (expWc) {
+            QL_REQUIRE(vmsc.expiries().size() == 1, "Wildcard expiry specified but more expiries also specified.");
+            DLOG("Have expiry wildcard pattern " << vmsc.expiries()[0]);
+        }
+        if (mnyWc) {
+            ELOG("Moneyness level does not support configuration by wildcard (*). Please specify levels explicitly.");
+            QL_FAIL("Moneyness level does not support configuration by wildcard (*). Please specify levels explicitly.");
+        }
+
+        // Parse, sort and check the vector of configured moneyness levels
+        vector<Real> moneynessLevels = checkMoneyness(vmsc.moneynessLevels());
+
+        // Map to hold the rows of the equity volatility matrix. The keys are the expiry dates and the values are the
+        // vectors of volatilities, one for each configured moneyness.
+        map<Date, vector<Real>> surfaceData;
+
+        // Count the number of quotes added. We check at the end that we have added all configured quotes.
+        Size quotesAdded = 0;
+
+        // Configured moneyness type.
+        MoneynessStrike::Type moneynessType = parseMoneynessType(vmsc.moneynessType());
+        
+        // Populate the configured strikes.
+        vector<boost::shared_ptr<BaseStrike>> strikes;
+        for (const auto& moneynessLevel : moneynessLevels) {
+            strikes.push_back(boost::make_shared<MoneynessStrike>(moneynessType, moneynessLevel));
+        }
+
+        // Read the quotes to fill the expiry dates and vols matrix.
+        for (const boost::shared_ptr<MarketDatum>& md : loader.loadQuotes(asof)) {
+            // Go to next quote if the market data point's date does not equal our asof.
+            if (md->asofDate() != asof)
+                continue;
+
+            // Go to next quote if not a equity option quote.
+            auto q = boost::dynamic_pointer_cast<EquityOptionQuote>(md);
+            if (!q)
+                continue;
+
+            // Go to next quote if not a equity name or currency do not match config.
+            if (vc.curveID() != q->eqName() || vc.ccy() != q->ccy())
+                continue;
+
+            // Iterator to one of the configured strikes.
+            vector<boost::shared_ptr<BaseStrike>>::iterator strikeIt;
+
+            if (!expWc) {
+                // If we have explicitly configured expiries and the quote is not in the configured quotes continue.
+                auto it = find(vc.quotes().begin(), vc.quotes().end(), q->name());
+                if (it == vc.quotes().end())
+                    continue;
+
+                // Check if quote's strike is in the configured strikes.
+                // It should be as we have selected from the explicitly configured quotes in the last step.
+                strikeIt = find_if(strikes.begin(), strikes.end(), [&q](boost::shared_ptr<BaseStrike> s) {
+                    return *s == *q->strike();
+                });
+                QL_REQUIRE(
+                    strikeIt != strikes.end(),
+                    "The quote '"
+                        << q->name()
+                        << "' is in the list of configured quotes but does not match any of the configured strikes");
+
+            } else {
+                // Check if quote's strike is in the configured strikes and continue if it is not.
+                strikeIt = find_if(strikes.begin(), strikes.end(),
+                                   [&q](boost::shared_ptr<BaseStrike> s) { return *s == *q->strike(); });
+                if (strikeIt == strikes.end())
+                    continue;
+            }
+
+            // Position of quote in vector of strikes
+            Size pos = std::distance(strikes.begin(), strikeIt);
+
+            // Process the quote
+            // TODO: The function call used to populate expiryDate might need correction for future rolling conventions?
+            // Original function call from commodityvolcurve.cpp is the one commented out below. 
+            // Control after surface if expiries seem off.
+            Date expiryDate = getDateFromDateOrPeriod(q->expiry(), asof, calendar_);
+            // Usage in commodityvolcurve.cpp: Date expiryDate = getExpiry(asof, q->expiry(), vc.futureConventionsId(), vc.optionExpiryRollDays());
+
+            // Add quote to surface
+            if (surfaceData.count(expiryDate) == 0)
+                surfaceData[expiryDate] = vector<Real>(moneynessLevels.size(), Null<Real>());
+
+            QL_REQUIRE(surfaceData[expiryDate][pos] == Null<Real>(),
+                       "Quote " << q->name() << " provides a duplicate quote for the date " << io::iso_date(expiryDate)
+                                << " and strike " << *q->strike());
+            surfaceData[expiryDate][pos] = q->quote()->value();
+            quotesAdded++;
+
+            TLOG("Added quote " << q->name() << ": (" << io::iso_date(expiryDate) << "," << *q->strike() << fixed
+                                << setprecision(9) << "," << q->quote()->value() << ")");
+        }
+
+        LOG("EquityVolCurve: added " << quotesAdded << " quotes in building moneyness strike surface.");
+        
+        // Check the data gathered.
+        if (!expWc) {
+            // If expiries were configured explicitly, the number of configured quotes should equal the
+            // number of quotes added.
+            QL_REQUIRE(vc.quotes().size() == quotesAdded, "Found " << quotesAdded << " quotes, but "
+                                                                   << vc.quotes().size()
+                                                                   << " quotes required by config.");
+        } else {
+            // If the expiries were configured via a wildcard, check that no surfaceData element has a Null<Real>().
+            for (const auto& kv : surfaceData) {
+                for (Size j = 0; j < moneynessLevels.size(); j++) {
+                    QL_REQUIRE(kv.second[j] != Null<Real>(),
+                               "Volatility for expiry date " << io::iso_date(kv.first) << " and strike " << *strikes[j]
+                                                             << " not found. Cannot proceed with a sparse matrix.");
+                }
+            }
+        }
+
+        // Populate the volatility quotes and the expiry times.
+        // Rows are moneyness levels and columns are expiry times - this is what the ctor needs below.
+        vector<Date> expiryDates(surfaceData.size());
+        vector<Time> expiryTimes(surfaceData.size());
+        vector<vector<Handle<Quote>>> vols(moneynessLevels.size());
+        for (const auto& row : surfaceData | boost::adaptors::indexed(0)) {
+            expiryDates[row.index()] = row.value().first;
+            expiryTimes[row.index()] = dayCounter_.yearFraction(asof, row.value().first);
+            for (Size i = 0; i < row.value().second.size(); i++) {
+                vols[i].push_back(Handle<Quote>(boost::make_shared<SimpleQuote>(row.value().second[i])));
+            }
+        }
+
+        // Set the strike extrapolation which only matters if extrapolation is turned on for the whole surface.
+        // BlackVarianceSurfaceMoneyness time extrapolation is hard-coded to constant in volatility.
+        bool flatExtrapolation = true;
+        if (vmsc.extrapolation()) {
+            auto strikeExtrapType = parseExtrapolation(vmsc.strikeExtrapolation());
+
+            if (strikeExtrapType == Extrapolation::UseInterpolator) {
+                DLOG("Strike extrapolation switched to using interpolator.");
+                flatExtrapolation = false;
+            } else if (strikeExtrapType == Extrapolation::None) {
+                DLOG("Strike extrapolation cannot be turned off on its own so defaulting to flat.");
+            } else if (strikeExtrapType == Extrapolation::Flat) {
+                DLOG("Strike extrapolation has been set to flat.");
+            } else {
+                DLOG("Strike extrapolation " << strikeExtrapType << " not expected so default to flat.");
+            }
+
+            auto timeExtrapType = parseExtrapolation(vmsc.timeExtrapolation());
+            if (timeExtrapType != Extrapolation::Flat) {
+                DLOG("BlackVarianceSurfaceMoneyness only supports flat volatility extrapolation in the time direction.");
+            }
+        } else {
+            DLOG("Extrapolation is turned off for the whole surface so the time and"
+                 << " strike extrapolation settings are ignored.");
+        }
+
+        // Time interpolation
+        if (vmsc.timeInterpolation() != "Linear") {
+            DLOG("BlackVarianceSurfaceMoneyness only supports linear time interpolation in variance.");
+        }
+
+        // Strike interpolation
+        if (vmsc.strikeInterpolation() != "Linear") {
+            DLOG("BlackVarianceSurfaceMoneyness only supports linear strike interpolation in variance.");
+        }
+
+        // Verify that the equity index holds required term structures
+        QL_REQUIRE(!eqInd_.empty(), "Expected the equity index with forecast and dividend yts to be \
+            populated for a moneyness surface.");
+
+        // Both moneyness surfaces need a spot quote.
+        Handle<Quote> spot(eqInd_->equitySpot());
+
+        // The choice of false here is important for forward moneyness. It means that we use the ceqInd and yts in the
+        // BlackVarianceSurfaceMoneynessForward to get the forward value at all times and in particular at times that
+        // are after the last expiry time. If we set it to true, BlackVarianceSurfaceMoneynessForward uses a linear
+        // interpolated forward curve on the expiry times internally which is poor.
+        bool stickyStrike = false;
+
+        if (moneynessType == MoneynessStrike::Type::Forward) {
+            QL_REQUIRE(!yts_.empty(), "Expected yield term structure to be populated for a forward moneyness surface.");
+            Handle<YieldTermStructure> divyts = Handle<YieldTermStructure>(eqInd_->equityDividendCurve());
+            divyts->enableExtrapolation();
+
+            DLOG("Creating BlackVarianceSurfaceMoneynessForward object.");
+            vol_ = boost::make_shared<BlackVarianceSurfaceMoneynessForward>(
+                calendar_, spot, expiryTimes, moneynessLevels, vols, dayCounter_, divyts, yts_, stickyStrike,
+                flatExtrapolation);
+        } else {
+            DLOG("Creating BlackVarianceSurfaceMoneynessSpot object.");
+            vol_ = boost::make_shared<BlackVarianceSurfaceMoneynessSpot>(
+                calendar_, spot, expiryTimes, moneynessLevels, vols, dayCounter_, stickyStrike, flatExtrapolation);
+        }
+
+        DLOG("Setting BlackVarianceSurfaceMoneyness extrapolation to " << to_string(vmsc.extrapolation()));
+        vol_->enableExtrapolation(vmsc.extrapolation());
+
+        LOG("EquityVolCurve: finished building 2-D volatility moneyness strike surface.");
+    } catch (const std::exception& e) {
+        QL_FAIL("equity vol curve building failed :" << e.what());
+    }
+    catch (...) {
         QL_FAIL("equity vol curve building failed: unknown error");
     }
 }
@@ -501,6 +754,41 @@ void EquityVolCurve::buildVolatility(const QuantLib::Date& asof, const EquityVol
 
     vol_ = boost::make_shared<EquityBlackVolatilitySurfaceProxy>(
         proxyVolCurve->second->volTermStructure(), curve->second->equityIndex(), proxyCurve->second->equityIndex());
+}
+
+void EquityVolCurve::populateCurves(const EquityVolatilityCurveConfig& config,
+                                    const std::map<std::string, boost::shared_ptr<YieldCurve>>& yieldCurves,
+                                    const std::map<std::string, boost::shared_ptr<EquityCurve>>& equityCurves,
+                                    const bool deltaOrFwdMoneyness) {
+
+    if (deltaOrFwdMoneyness) {
+        QL_REQUIRE(!config.yieldCurveId().empty(), "YieldCurveId must be populated to build delta or "
+                                                       << "forward moneyness surface.");
+        auto itYts = yieldCurves.find(config.yieldCurveId());
+        QL_REQUIRE(itYts != yieldCurves.end(), "Can't find yield curve with id " << config.yieldCurveId());
+        yts_ = itYts->second->handle();
+    }
+
+    QL_REQUIRE(!config.equityCurveId().empty(), "EquityCurveId must be populated to build delta or moneyness surface.");
+    auto itEqc = equityCurves.find(config.equityCurveId());
+    QL_REQUIRE(itEqc != equityCurves.end(), "Can't find equity curve with id " << config.equityCurveId());
+    eqInd_ = Handle<EquityIndex>(itEqc->second->equityIndex());
+}
+
+vector<Real> EquityVolCurve::checkMoneyness(const vector<string>& strMoneynessLevels) const {
+    using boost::adaptors::transformed;
+    using boost::algorithm::join;
+
+    vector<Real> moneynessLevels = parseVectorOfValues<Real>(strMoneynessLevels, &parseReal);
+    sort(moneynessLevels.begin(), moneynessLevels.end(), [](Real x, Real y) { return !close(x, y) && x < y; });
+    QL_REQUIRE(adjacent_find(moneynessLevels.begin(), moneynessLevels.end(),
+                             [](Real x, Real y) { return close(x, y); }) == moneynessLevels.end(),
+               "The configured moneyness levels contain duplicates");
+    DLOG("Parsed " << moneynessLevels.size() << " unique configured moneyness levels.");
+    DLOG("The moneyness levels are: " << join(
+             moneynessLevels | transformed([](Real d) { return ore::data::to_string(d); }), ","));
+
+    return moneynessLevels;
 }
 
 } // namespace data

--- a/OREData/ored/marketdata/marketdatum.cpp
+++ b/OREData/ored/marketdata/marketdatum.cpp
@@ -56,7 +56,8 @@ std::ostream& operator<<(std::ostream& out, const MarketDatum::QuoteType& type) 
 }
 
 EquityOptionQuote::EquityOptionQuote(Real value, Date asofDate, const string& name, QuoteType quoteType,
-                                     string equityName, string ccy, string expiry, string strike, bool isCall)
+                                     string equityName, string ccy, string expiry,
+                                     const boost::shared_ptr<BaseStrike>& strike, bool isCall)
     : MarketDatum(value, asofDate, name, quoteType, InstrumentType::EQUITY_OPTION), eqName_(equityName), ccy_(ccy),
       expiry_(expiry), strike_(strike), isCall_(isCall) {
 

--- a/OREData/ored/marketdata/marketdatum.hpp
+++ b/OREData/ored/marketdata/marketdatum.hpp
@@ -1531,21 +1531,21 @@ public:
     EquityOptionQuote() {}
     //! Constructor
     EquityOptionQuote(Real value, Date asofDate, const string& name, QuoteType quoteType, string equityName, string ccy,
-                      string expiry, string strike, bool isCall = true);
+                      string expiry, const boost::shared_ptr<BaseStrike>& strike, bool isCall = true);
 
     //! \name Inspectors
     //@{
     const string& eqName() const { return eqName_; }
     const string& ccy() const { return ccy_; }
     const string& expiry() const { return expiry_; }
-    const string& strike() const { return strike_; }
+    const boost::shared_ptr<BaseStrike>& strike() const { return strike_; }
     bool isCall() { return isCall_; }
     //@}
 private:
     string eqName_;
     string ccy_;
     string expiry_;
-    string strike_;
+    boost::shared_ptr<BaseStrike> strike_;
     bool isCall_;
     //! Serialization
     friend class boost::serialization::access;

--- a/OREData/ored/marketdata/todaysmarket.cpp
+++ b/OREData/ored/marketdata/todaysmarket.cpp
@@ -600,8 +600,9 @@ TodaysMarket::TodaysMarket(const Date& asof, const TodaysMarketParameters& param
                             MarketImpl::equityCurve(eqvolspec->curveConfigID(), configuration.first);
 
                         boost::shared_ptr<EquityVolCurve> eqVolCurve =
-                            boost::make_shared<EquityVolCurve>(asof, *eqvolspec, loader, curveConfigs, eqIndex,
-                                                               requiredEquityCurves, requiredEquityVolCurves);
+                            boost::make_shared<EquityVolCurve>(asof, *eqvolspec, loader, curveConfigs, eqIndex, 
+                                                               requiredYieldCurves, requiredEquityCurves, 
+                                                               requiredEquityVolCurves);
                         itr = requiredEquityVolCurves.insert(make_pair(eqvolspec->name(), eqVolCurve)).first;
                     }
 


### PR DESCRIPTION
Updated EquityOptionQuote strike to use BaseStrike class instead of strings. Specified that EquityCurve uses AbsoluteStrikes for option premiums to ensure previous functionality. Added tags to define MoneynessSurface config to EquityVolCurveConfig, along with extra required member variables.  Also added additional logging for debugging purposes, and spelling corrections.

Notes: Needs checking for correct handling of ATM quotes in vol strike surface and option premium equity curves. Marketdatumparser is also good to check on if developing further. Will do separate PR for volatility interpolation dimensions.