### PR TITLE
Patches ATM strike dereferencing bug

### DIFF
--- a/OREData/ored/marketdata/strike.cpp
+++ b/OREData/ored/marketdata/strike.cpp
@@ -141,8 +141,8 @@ string AtmStrike::toString() const {
 
 bool AtmStrike::equal_to(const BaseStrike& other) const {
     if (const AtmStrike* p = dynamic_cast<const AtmStrike*>(&other)) {
-        return !(atmType_ != p->atmType() || (deltaType_ && !p->deltaType()) || (!deltaType_ && p->deltaType()) ||
-                 *deltaType_ != *p->deltaType());
+        return (atmType_ == p->atmType()) &&
+               ((!deltaType_ && !p->deltaType()) || (deltaType_ && p->deltaType() && (*deltaType_ == *p->deltaType())));
     } else {
         return false;
     }

--- a/OREData/test/strike.cpp
+++ b/OREData/test/strike.cpp
@@ -113,6 +113,20 @@ BOOST_AUTO_TEST_CASE(testAtmStrikeNoDelta) {
     BOOST_CHECK(!castStrike->deltaType());
 }
 
+BOOST_AUTO_TEST_CASE(testAtmStrikeNoDeltaEquality) {
+
+    BOOST_TEST_MESSAGE("Testing equality operator for two ATM strikes without delta...");
+    // Checks for failure in operator== if delta type is not given
+
+    DeltaVolQuote::AtmType atmType = DeltaVolQuote::AtmFwd;
+    boost::optional<DeltaVolQuote::DeltaType> atmDeltaType;
+
+    vector<boost::shared_ptr<BaseStrike>> strikes;
+    strikes.push_back(boost::make_shared<AtmStrike>(atmType, atmDeltaType));
+    strikes.push_back(boost::make_shared<AtmStrike>(DeltaVolQuote::AtmFwd));
+    BOOST_REQUIRE(*strikes[0] == *strikes[1]);
+}
+
 BOOST_AUTO_TEST_CASE(testAtmStrikeWithDelta) {
 
     BOOST_TEST_MESSAGE("Testing ATM strike with delta...");


### PR DESCRIPTION
Fixes issue where the operator == for AtmStrike throws an exception if deltaType_ is not initialized when dereferenced. A unit test is added to verify the correctness of the updated return statement.