### PR TITLE
Retarget VS project to use latest Windows SDK

### DIFF
--- a/App/ore.vcxproj
+++ b/App/ore.vcxproj
@@ -39,7 +39,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ore</RootNamespace>
     <ProjectName>ore</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\ore.props" />


### PR DESCRIPTION
With the ORE 6 release, _ore.vcxproj_ started requiring Windows SDK version 10.0.17763.0 specifically, probably unintentionally. Other versions, e.g. 10.0.18362.0 on my machine, will cause the _ore_ project to fail building in VS, raising _MSB8036_. Relaxing this to 10.0 makes building the solution easier as it allows for using the latest version available on the machine. 