### PR TITLE
Add missing filter for Asian option files

### DIFF
--- a/OREData/OREData.vcxproj.filters
+++ b/OREData/OREData.vcxproj.filters
@@ -1127,10 +1127,20 @@
     <ClCompile Include="ored\portfolio\builders\capflooredaverageonindexedcouponleg.cpp">
       <Filter>portfolio\builders</Filter>
     </ClCompile>
-    <ClCompile Include="ored\portfolio\asianoption.cpp" />
-    <ClCompile Include="ored\portfolio\commodityasianoption.cpp" />
-    <ClCompile Include="ored\portfolio\equityasianoption.cpp" />
-    <ClCompile Include="ored\portfolio\fxasianoption.cpp" />
-    <ClCompile Include="ored\portfolio\optionasiandata.cpp" />
+    <ClCompile Include="ored\portfolio\commodityasianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\equityasianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\fxasianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\optionasiandata.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
+    <ClCompile Include="ored\portfolio\asianoption.cpp">
+      <Filter>portfolio</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It seems the filters for some of the Asian option files got lost in the ether during the ORE 6 upgrade. Here's a quick fix to bring them back.