### PR TITLE
Add Euribor365 to XSD and user guide

### DIFF
--- a/Docs/UserGuide/allowablevalues.tex
+++ b/Docs/UserGuide/allowablevalues.tex
@@ -237,7 +237,7 @@ Note: Currency codes must also match available currencies in the {\tt simulation
 CCY-INDEX                &
                            \textit{\begin{tabular}[c]{@{}l@{}}
 EUR-EONIA\\ EUR-ESTER, EUR-ESTR, EUR-STR 
-\\ EUR-EURIBOR\\ EUR-LIBOR\\ EUR-CMS\\
+\\ EUR-EURIBOR, EUR-EURIBOR365\\ EUR-LIBOR\\ EUR-CMS\\
 USD-FedFunds\\ USD-SOFR \\ USD-Prime\\ USD-LIBOR\\ USD-SIFMA\\ USD-CMS\\
 GBP-SONIA\\ GBP-LIBOR\\ GBP-CMS \\ GBP-BoEBase \\ 
 JPY-LIBOR\\ JPY-TIBOR \\ JPY-EYTIBOR \\ JPY-TONAR \\ JPY-CMS \\

--- a/xsd/ore_types.xsd
+++ b/xsd/ore_types.xsd
@@ -22,9 +22,10 @@
   </xs:simpleType>
 
   <xs:simpleType name="indexNameType">
-    <!-- Index name is of form CCY-NAME or CCY-NAME-TENOR max length is EUR-EURIBOR-12M or FX-SOURCE-CCY1-CCY2 -->
+    <!-- Index name is of form CCY-NAME, CCY-NAME-TENOR or FX-SOURCE-CCY1-CCY2. 
+         Max length is set by EUR-EURIBOR365-12M -->
     <xs:restriction base="xs:string">
-      <xs:maxLength value="15"/>
+      <xs:maxLength value="18"/>
       <!-- This is not strict.
            - CCY is any 3 uppercase character string (can we use the below currencyCode list?)
            - NAME is any 3 to 8 character string ("CMS" up to "FedFunds") plus an optional 365 for EURIBOR365

--- a/xsd/ore_types.xsd
+++ b/xsd/ore_types.xsd
@@ -27,10 +27,10 @@
       <xs:maxLength value="15"/>
       <!-- This is not strict.
            - CCY is any 3 uppercase character string (can we use the below currencyCode list?)
-           - NAME is any 3 to 8 character string ("CMS" up to "FedFunds")
+           - NAME is any 3 to 8 character string ("CMS" up to "FedFunds") plus an optional 365 for EURIBOR365
            - TENOR is any 1 to 3 digit followed by one of YMWD (99M would pass)
         -->
-      <xs:pattern value="\p{Lu}{3}-\c{3,8}|\p{Lu}{3}-\c{3,8}-\d{1,3}[YMWD]|\c{2}-\c{1,8}-\p{Lu}{3}-\p{Lu}{3}"/>
+      <xs:pattern value="\p{Lu}{3}-\c{3,8}|\p{Lu}{3}-\c{3,8}(365)?-\d{1,3}[YMWD]|\c{2}-\c{1,8}-\p{Lu}{3}-\p{Lu}{3}"/>
     </xs:restriction>
   </xs:simpleType>
 


### PR DESCRIPTION
We have noticed that Euribor365 is correctly parsed within `parseIborIndex()` although it is rejected by the XSD regex for _indexNameType_ and not listed in the user guide. I have added support for this, allowing an optional 365 in the index name, as it helps us distinguish trades in our portfolios and avoids messing up the daycounts. 

Best,
Fredrik