### PR TITLE
Allow cap/floor cashflows to be printed

### DIFF
--- a/OREData/ored/portfolio/capfloor.hpp
+++ b/OREData/ored/portfolio/capfloor.hpp
@@ -53,11 +53,6 @@ public:
     virtual void fromXML(XMLNode* node) override;
     virtual XMLNode* toXML(XMLDocument& doc) override;
 
-    //! \name Trade
-    //@{
-    bool hasCashflows() const override { return false; }
-    //@}
-
 private:
     string longShort_;
     LegData legData_;


### PR DESCRIPTION
Cap and floor trades had their cashflow outputs suppressed in the ORE 5 release which I believe they should not have. I have removed the overridden function to allow the printing once again as it helps greatly in the validation of trades, seeing as caps/floors don't produce any additional results or data yet. I am intending on doing something about that soon, at least such that the vols used for each cashflow may be extracted. 

Best,
Fredrik