### PR TITLE
Additional results for cap/floor trades

### DIFF
--- a/OREData/ored/portfolio/capfloor.hpp
+++ b/OREData/ored/portfolio/capfloor.hpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -57,6 +58,7 @@ public:
     //@{
     bool hasCashflows() const override { return false; }
     //@}
+    const std::map<std::string, boost::any>& additionalData() const override;
 
 private:
     string longShort_;

--- a/OREData/test/cpicapfloor.cpp
+++ b/OREData/test/cpicapfloor.cpp
@@ -27,6 +27,7 @@
 #include <ored/marketdata/fixings.hpp>
 #include <ored/marketdata/todaysmarket.hpp>
 #include <ored/marketdata/todaysmarketparameters.hpp>
+#include <ored/portfolio/capfloor.hpp>
 #include <ored/portfolio/enginefactory.hpp>
 #include <ored/portfolio/portfolio.hpp>
 #include <ored/utilities/csvfilereader.hpp>
@@ -131,6 +132,9 @@ BOOST_DATA_TEST_CASE_F(F, testCapConsistency, bdata::make(testCases), testCase) 
         BOOST_TEST_MESSAGE("trade " << p.trades()[i]->id() << " npv " << p.trades()[i]->instrument()->NPV());
         sum += p.trades()[i]->instrument()->NPV();
         minimumNPV = std::min(minimumNPV, fabs(p.trades()[i]->instrument()->NPV()));
+        auto cf = boost::dynamic_pointer_cast<ore::data::CapFloor>(p.trades()[i]);
+        if (cf)
+            BOOST_CHECK_NO_THROW(cf->additionalData());
     }
     BOOST_TEST_MESSAGE("mininim absolute NPV = " << minimumNPV);
     Real tolerance = 1.0e-8 * minimumNPV;

--- a/OREData/test/inflationcapfloor.cpp
+++ b/OREData/test/inflationcapfloor.cpp
@@ -181,6 +181,7 @@ BOOST_AUTO_TEST_CASE(testYoYCapFloor) {
         market->yoyInflationIndex("EUHICPXT").currentLink(), hovs, nominalTs);
     qlCap->setPricingEngine(dscEngine);
     BOOST_CHECK_CLOSE(yyCap->instrument()->NPV(), qlCap->NPV(), 1E-8); // this is 1E-10 rel diff
+    BOOST_CHECK_NO_THROW(yyCap->additionalData());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
We have added some functionality to the `CapFloor` class to generate additional outputs for the validation of cap/floor trades. The data includes:
	- coupon amounts,
	- coupon rates,
	- coupon fixings,
	- coupon notionals,
	- (effective) optionlet rates,
	- optionlet volatilities, and
	- optionlet prices.

Some of this may overlap with what is produced by the _flows_ report (enabled in #87) but it may still prove useful to include the results here as well. I am also open to adding or removing certain points for the sake of efficiency or to reduce the (sometimes large) number of outputs. The code would need amendments for the results of non-Ibor trades, although I don't have the ability to evaluate that for the time being. It seems to pass all tests as it looks now. 

Best regards,
Fredrik