### PR TITLE
Isda engine for CDS pricing

### DIFF
--- a/Examples/Input/pricingengine.xml
+++ b/Examples/Input/pricingengine.xml
@@ -156,6 +156,19 @@
     <Engine>MidPointCdsEngine</Engine>
     <EngineParameters/>
   </Product>
+  <Product type="CreditDefaultSwap_DEACTIVATED">
+    <Model>DiscountedCashflows</Model>
+    <ModelParameters/>
+    <Engine>IsdaCdsEngine</Engine>
+    <EngineParameters>
+      <!-- [Optional] Taylor (default) or None -->
+      <Parameter name="NumericalFix">Taylor</Parameter>
+      <!-- [Optional] HalfDayBias (default) or NoBias -->
+      <Parameter name="AccrualBias">HalfDayBias</Parameter>
+      <!-- [Optional] Piecewise (default) or Flat -->
+      <Parameter name="ForwardsInCouponPeriod">Piecewise</Parameter>
+    </EngineParameters>
+  </Product>
   <Product type="CreditDefaultSwapOption">
     <Model>Black</Model>
     <ModelParameters/>

--- a/OREData/ored/portfolio/builders/creditdefaultswap.hpp
+++ b/OREData/ored/portfolio/builders/creditdefaultswap.hpp
@@ -30,7 +30,7 @@
 #include <ored/utilities/parsers.hpp>
 
 #include <qle/pricingengines/midpointcdsengine.hpp>
-#include <ql/pricingengines/credit/isdacdsengine.hpp>
+#include <qle/pricingengines/isdacdsengine.hpp>
 
 #include <boost/make_shared.hpp>
 
@@ -163,7 +163,7 @@ protected:
 };
 
 //! ISDA engine builder class for credit default swaps
-/*! This class creates a QuantLib::IsdaCdsEngine
+/*! This class creates a QuantExt::IsdaCdsEngine
     \ingroup builders
 */
 class IsdaCdsEngineBuilder : public CreditDefaultSwapEngineBuilder {
@@ -184,7 +184,7 @@ protected:
             recoveryRate = market_->recoveryRate(creditCurveId, cfg)->value();
         }
 
-        using QuantLib::IsdaCdsEngine;
+        using QuantExt::IsdaCdsEngine;
 
         IsdaCdsEngine::NumericalFix numericalFix =
             parseNumericalFix(engineParameter("NumericalFix", "", false, "Taylor"));

--- a/OREData/ored/portfolio/creditdefaultswap.hpp
+++ b/OREData/ored/portfolio/creditdefaultswap.hpp
@@ -17,7 +17,7 @@
 */
 
 /*! \file portfolio/creditdefaultswap.hpp
- \brief Ibor cap, floor or collar trade data model and serialization
+ \brief Credit default swap trade data model and serialization
  \ingroup tradedata
  */
 

--- a/OREData/ored/portfolio/enginefactory.cpp
+++ b/OREData/ored/portfolio/enginefactory.cpp
@@ -208,6 +208,7 @@ void EngineFactory::addDefaultBuilders() {
     registerBuilder(boost::make_shared<data::LinearTsrDurationAdjustedCmsCouponPricerBuilder>());
 
     registerBuilder(boost::make_shared<MidPointCdsEngineBuilder>());
+    registerBuilder(boost::make_shared<IsdaCdsEngineBuilder>());
     registerBuilder(boost::make_shared<BlackCdsOptionEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityForwardEngineBuilder>());
     registerBuilder(boost::make_shared<CommodityEuropeanOptionEngineBuilder>());

--- a/OREData/ored/utilities/parsers.cpp
+++ b/OREData/ored/utilities/parsers.cpp
@@ -1502,31 +1502,32 @@ Average::Type parseAverageType(const std::string& s) {
     }
 }
 
-QuantLib::IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s) {
+using QuantExt::IsdaCdsEngine;
+IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s) {
     if (s == "None") {
-        return QuantLib::IsdaCdsEngine::NumericalFix::None;
+        return IsdaCdsEngine::NumericalFix::None;
     } else if (s == "Taylor") {
-        return QuantLib::IsdaCdsEngine::NumericalFix::Taylor;
+        return IsdaCdsEngine::NumericalFix::Taylor;
     } else {
         QL_FAIL("IsdaCdsEngine::NumericalFix '" << s << "' not recognized. Should be None or Taylor.");
     }
 }
 
-QuantLib::IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s) {
+IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s) {
     if (s == "HalfDayBias") {
-        return QuantLib::IsdaCdsEngine::AccrualBias::HalfDayBias;
+        return IsdaCdsEngine::AccrualBias::HalfDayBias;
     } else if (s == "NoBias") {
-        return QuantLib::IsdaCdsEngine::AccrualBias::NoBias;
+        return IsdaCdsEngine::AccrualBias::NoBias;
     } else {
         QL_FAIL("IsdaCdsEngine::AccrualBias '" << s << "' not recognized. Should be HalfDayBias or NoBias.");
     }
 }
 
-QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s) {
+IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s) {
     if (s == "Flat") {
-        return QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod::Flat;
+        return IsdaCdsEngine::ForwardsInCouponPeriod::Flat;
     } else if (s == "Piecewise") {
-        return QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod::Piecewise;
+        return IsdaCdsEngine::ForwardsInCouponPeriod::Piecewise;
     } else {
         QL_FAIL("IsdaCdsEngine::ForwardsInCouponPeriod '" << s << "' not recognized. Should be Flat or Piecewise.");
     }

--- a/OREData/ored/utilities/parsers.cpp
+++ b/OREData/ored/utilities/parsers.cpp
@@ -1502,5 +1502,35 @@ Average::Type parseAverageType(const std::string& s) {
     }
 }
 
+QuantLib::IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s) {
+    if (s == "None") {
+        return QuantLib::IsdaCdsEngine::NumericalFix::None;
+    } else if (s == "Taylor") {
+        return QuantLib::IsdaCdsEngine::NumericalFix::Taylor;
+    } else {
+        QL_FAIL("IsdaCdsEngine::NumericalFix '" << s << "' not recognized. Should be None or Taylor.");
+    }
+}
+
+QuantLib::IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s) {
+    if (s == "HalfDayBias") {
+        return QuantLib::IsdaCdsEngine::AccrualBias::HalfDayBias;
+    } else if (s == "NoBias") {
+        return QuantLib::IsdaCdsEngine::AccrualBias::NoBias;
+    } else {
+        QL_FAIL("IsdaCdsEngine::AccrualBias '" << s << "' not recognized. Should be HalfDayBias or NoBias.");
+    }
+}
+
+QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s) {
+    if (s == "Flat") {
+        return QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod::Flat;
+    } else if (s == "Piecewise") {
+        return QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod::Piecewise;
+    } else {
+        QL_FAIL("IsdaCdsEngine::ForwardsInCouponPeriod '" << s << "' not recognized. Should be Flat or Piecewise.");
+    }
+}
+
 } // namespace data
 } // namespace ore

--- a/OREData/ored/utilities/parsers.hpp
+++ b/OREData/ored/utilities/parsers.hpp
@@ -40,7 +40,6 @@
 #include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
 #include <ql/position.hpp>
-#include <ql/pricingengines/credit/isdacdsengine.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/date.hpp>
@@ -54,6 +53,7 @@
 #include <qle/models/crossassetmodel.hpp>
 #include <qle/methods/multipathgeneratorbase.hpp>
 #include <qle/currencies/configurablecurrency.hpp>
+#include <qle/pricingengines/isdacdsengine.hpp>
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/tokenizer.hpp>
@@ -435,22 +435,22 @@ QuantExt::CdsOption::StrikeType parseCdsOptionStrikeType(const std::string& s);
 /*! Convert text to QuantLib::Average::Type
     \ingroup utilities
 */
-QuantLib::Average::Type parseAverageType(const std::string& s);
+QuantExt::Average::Type parseAverageType(const std::string& s);
 
-/*! Convert text to QuantLib::IsdaCdsEngine::NumericalFix
+/*! Convert text to QuantExt::IsdaCdsEngine::NumericalFix
     \ingroup utilities
 */
-QuantLib::IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s);
+QuantExt::IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s);
 
-/*! Convert text to QuantLib::IsdaCdsEngine::AccrualBias
+/*! Convert text to QuantExt::IsdaCdsEngine::AccrualBias
     \ingroup utilities
 */
-QuantLib::IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s);
+QuantExt::IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s);
 
-/*! Convert text to QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod
+/*! Convert text to QuantExt::IsdaCdsEngine::ForwardsInCouponPeriod
     \ingroup utilities
 */
-QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s);
+QuantExt::IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s);
 
 } // namespace data
 } // namespace ore

--- a/OREData/ored/utilities/parsers.hpp
+++ b/OREData/ored/utilities/parsers.hpp
@@ -40,6 +40,7 @@
 #include <ql/methods/finitedifferences/solvers/fdmbackwardsolver.hpp>
 #include <ql/methods/montecarlo/lsmbasissystem.hpp>
 #include <ql/position.hpp>
+#include <ql/pricingengines/credit/isdacdsengine.hpp>
 #include <ql/time/businessdayconvention.hpp>
 #include <ql/time/calendar.hpp>
 #include <ql/time/date.hpp>
@@ -435,6 +436,21 @@ QuantExt::CdsOption::StrikeType parseCdsOptionStrikeType(const std::string& s);
     \ingroup utilities
 */
 QuantLib::Average::Type parseAverageType(const std::string& s);
+
+/*! Convert text to QuantLib::IsdaCdsEngine::NumericalFix
+    \ingroup utilities
+*/
+QuantLib::IsdaCdsEngine::NumericalFix parseNumericalFix(const std::string& s);
+
+/*! Convert text to QuantLib::IsdaCdsEngine::AccrualBias
+    \ingroup utilities
+*/
+QuantLib::IsdaCdsEngine::AccrualBias parseAccrualBias(const std::string& s);
+
+/*! Convert text to QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod
+    \ingroup utilities
+*/
+QuantLib::IsdaCdsEngine::ForwardsInCouponPeriod parseForwardsInCouponPeriod(const std::string& s);
 
 } // namespace data
 } // namespace ore

--- a/OREData/test/parser.cpp
+++ b/OREData/test/parser.cpp
@@ -766,7 +766,7 @@ BOOST_AUTO_TEST_CASE(testJointCalendar) {
 }
 
 BOOST_AUTO_TEST_CASE(testIsdaCdsEngineParsers) {
-    using QuantLib::IsdaCdsEngine;
+    using QuantExt::IsdaCdsEngine;
     using namespace ore::data;
 
     BOOST_TEST_MESSAGE("Testing NumericalFix parsing...");

--- a/OREData/test/parser.cpp
+++ b/OREData/test/parser.cpp
@@ -1,5 +1,6 @@
 /*
  Copyright (C) 2016 Quaternion Risk Management Ltd
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
  All rights reserved.
 
  This file is part of ORE, a free-software/open-source library
@@ -762,6 +763,23 @@ BOOST_AUTO_TEST_CASE(testJointCalendar) {
     hol = joint8.holidayList(Date(1, January, 2018), Date(31, December, 2018));
     BOOST_CHECK(hol.size() == expectedHolidays.size());
     checkCalendars(expectedHolidays, hol);
+}
+
+BOOST_AUTO_TEST_CASE(testIsdaCdsEngineParsers) {
+    using QuantLib::IsdaCdsEngine;
+    using namespace ore::data;
+
+    BOOST_TEST_MESSAGE("Testing NumericalFix parsing...");
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::NumericalFix::None, parseNumericalFix("None"));
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::NumericalFix::Taylor, parseNumericalFix("Taylor"));
+
+    BOOST_TEST_MESSAGE("Testing AccrualBias parsing...");
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::AccrualBias::HalfDayBias, parseAccrualBias("HalfDayBias"));
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::AccrualBias::NoBias, parseAccrualBias("NoBias"));
+
+    BOOST_TEST_MESSAGE("Testing ForwardsInCouponPeriod parsing...");
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::ForwardsInCouponPeriod::Flat, parseForwardsInCouponPeriod("Flat"));
+    BOOST_CHECK_EQUAL(IsdaCdsEngine::ForwardsInCouponPeriod::Piecewise, parseForwardsInCouponPeriod("Piecewise"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/QuantExt/QuantExt.vcxproj
+++ b/QuantExt/QuantExt.vcxproj
@@ -738,6 +738,7 @@
     <ClInclude Include="qle\pricingengines\discountingriskybondengine.hpp" />
     <ClInclude Include="qle\pricingengines\discountingswapenginemulticurve.hpp" />
     <ClInclude Include="qle\pricingengines\inflationcapfloorengines.hpp" />
+    <ClInclude Include="qle\pricingengines\isdacdsengine.hpp" />
     <ClInclude Include="qle\pricingengines\lgmconvolutionsolver.hpp" />
     <ClInclude Include="qle\pricingengines\midpointcdsengine.hpp" />
     <ClInclude Include="qle\pricingengines\numericlgmswaptionengine.hpp" />
@@ -1036,6 +1037,7 @@
     <ClCompile Include="qle\pricingengines\discountingriskybondengine.cpp" />
     <ClCompile Include="qle\pricingengines\discountingswapenginemulticurve.cpp" />
     <ClCompile Include="qle\pricingengines\inflationcapfloorengines.cpp" />
+    <ClCompile Include="qle\pricingengines\isdacdsengine.cpp" />
     <ClCompile Include="qle\pricingengines\lgmconvolutionsolver.cpp" />
     <ClCompile Include="qle\pricingengines\midpointcdsengine.cpp" />
     <ClCompile Include="qle\pricingengines\numericlgmswaptionengine.cpp" />

--- a/QuantExt/QuantExt.vcxproj.filters
+++ b/QuantExt/QuantExt.vcxproj.filters
@@ -1156,6 +1156,9 @@
     <ClInclude Include="qle\cashflows\nonstandardinflationcouponpricer.hpp">
       <Filter>cashflows</Filter>
     </ClInclude>
+    <ClInclude Include="qle\pricingengines\isdacdsengine.hpp">
+      <Filter>pricingengines</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="cashflows">
@@ -1969,6 +1972,9 @@
     </ClCompile>
     <ClCompile Include="qle\cashflows\nonstandardinflationcouponpricer.cpp">
       <Filter>cashflows</Filter>
+    </ClCompile>
+    <ClCompile Include="qle\pricingengines\isdacdsengine.cpp">
+      <Filter>pricingengines</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/QuantExt/qle/CMakeLists.txt
+++ b/QuantExt/qle/CMakeLists.txt
@@ -167,6 +167,7 @@ pricingengines/discountingfxforwardengine.cpp
 pricingengines/discountingriskybondengine.cpp
 pricingengines/discountingswapenginemulticurve.cpp
 pricingengines/inflationcapfloorengines.cpp
+pricingengines/isdacdsengine.cpp
 pricingengines/lgmconvolutionsolver.cpp
 pricingengines/midpointcdsengine.cpp
 pricingengines/numericlgmswaptionengine.cpp
@@ -501,6 +502,7 @@ pricingengines/discountingfxforwardengine.hpp
 pricingengines/discountingriskybondengine.hpp
 pricingengines/discountingswapenginemulticurve.hpp
 pricingengines/inflationcapfloorengines.hpp
+pricingengines/isdacdsengine.hpp
 pricingengines/lgmconvolutionsolver.hpp
 pricingengines/midpointcdsengine.hpp
 pricingengines/numericlgmswaptionengine.hpp

--- a/QuantExt/qle/pricingengines/isdacdsengine.cpp
+++ b/QuantExt/qle/pricingengines/isdacdsengine.cpp
@@ -1,0 +1,321 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*
+ Copyright (C) 2014 Jose Aparicio
+ Copyright (C) 2014 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+#include <qle/pricingengines/isdacdsengine.hpp>
+
+#include <ql/cashflows/fixedratecoupon.hpp>
+#include <ql/instruments/claim.hpp>
+#include <ql/math/interpolations/forwardflatinterpolation.hpp>
+#include <ql/termstructures/credit/flathazardrate.hpp>
+#include <ql/termstructures/credit/piecewisedefaultcurve.hpp>
+#include <ql/termstructures/yield/flatforward.hpp>
+#include <ql/termstructures/yield/piecewiseyieldcurve.hpp>
+#include <ql/time/calendars/weekendsonly.hpp>
+#include <ql/time/daycounters/actual360.hpp>
+#include <utility>
+
+namespace QuantExt {
+
+IsdaCdsEngine::IsdaCdsEngine(Handle<DefaultProbabilityTermStructure> probability, Real recoveryRate,
+                             Handle<YieldTermStructure> discountCurve,
+                             const boost::optional<bool>& includeSettlementDateFlows, const NumericalFix numericalFix,
+                             const AccrualBias accrualBias, const ForwardsInCouponPeriod forwardsInCouponPeriod)
+    : probability_(std::move(probability)), recoveryRate_(recoveryRate), discountCurve_(std::move(discountCurve)),
+      includeSettlementDateFlows_(includeSettlementDateFlows), numericalFix_(numericalFix), accrualBias_(accrualBias),
+      forwardsInCouponPeriod_(forwardsInCouponPeriod) {
+
+    registerWith(probability_);
+    registerWith(discountCurve_);
+}
+
+void IsdaCdsEngine::calculate() const {
+
+    QL_REQUIRE(numericalFix_ == None || numericalFix_ == Taylor, "numerical fix must be None or Taylor");
+    QL_REQUIRE(accrualBias_ == HalfDayBias || accrualBias_ == NoBias, "accrual bias must be HalfDayBias or NoBias");
+    QL_REQUIRE(forwardsInCouponPeriod_ == Flat || forwardsInCouponPeriod_ == Piecewise,
+               "forwards in coupon period must be Flat or Piecewise");
+
+    // it would be possible to handle the cases which are excluded below,
+    // but the ISDA engine is not explicitly specified to handle them,
+    // so we just forbid them too
+
+    Actual365Fixed dc;
+    Actual360 dc1;
+    Actual360 dc2(true);
+
+    Date evalDate = Settings::instance().evaluationDate();
+
+    // check if given curves are ISDA compatible
+    // (the interpolation is checked below)
+
+    QL_REQUIRE(!discountCurve_.empty(), "no discount term structure set");
+    QL_REQUIRE(!probability_.empty(), "no probability term structure set");
+    QL_REQUIRE(discountCurve_->dayCounter() == dc,
+               "yield term structure day counter (" << discountCurve_->dayCounter() << ") should be Act/365(Fixed)");
+    QL_REQUIRE(probability_->dayCounter() == dc, "probability term structure day counter ("
+                                                     << probability_->dayCounter() << ") should be "
+                                                     << "Act/365(Fixed)");
+    QL_REQUIRE(discountCurve_->referenceDate() == evalDate, "yield term structure reference date ("
+                                                                << discountCurve_->referenceDate()
+                                                                << " should be evaluation date (" << evalDate << ")");
+    QL_REQUIRE(probability_->referenceDate() == evalDate, "probability term structure reference date ("
+                                                              << probability_->referenceDate()
+                                                              << " should be evaluation date (" << evalDate << ")");
+    QL_REQUIRE(arguments_.settlesAccrual, "ISDA engine not compatible with non accrual paying CDS");
+    QL_REQUIRE(arguments_.protectionPaymentTime == CreditDefaultSwap::ProtectionPaymentTime::atDefault,
+               "ISDA engine not compatible with end period or maturity payment");
+    QL_REQUIRE(ext::dynamic_pointer_cast<FaceValueClaim>(arguments_.claim) != nullptr,
+               "ISDA engine not compatible with non face value claim");
+
+    Date maturity = arguments_.maturity;
+    Date effectiveProtectionStart = std::max<Date>(arguments_.protectionStart, evalDate + 1);
+
+    // collect nodes from both curves and sort them
+    std::vector<Date> yDates, cDates;
+
+    if (ext::shared_ptr<InterpolatedDiscountCurve<LogLinear> > castY1 =
+            ext::dynamic_pointer_cast<InterpolatedDiscountCurve<LogLinear> >(*discountCurve_)) {
+        yDates = castY1->dates();
+    } else if (ext::shared_ptr<InterpolatedForwardCurve<BackwardFlat> > castY2 =
+                   ext::dynamic_pointer_cast<InterpolatedForwardCurve<BackwardFlat> >(*discountCurve_)) {
+        yDates = castY2->dates();
+    } else if (ext::shared_ptr<InterpolatedForwardCurve<ForwardFlat> > castY3 =
+                   ext::dynamic_pointer_cast<InterpolatedForwardCurve<ForwardFlat> >(*discountCurve_)) {
+        yDates = castY3->dates();
+    } else if (ext::shared_ptr<FlatForward> castY4 = ext::dynamic_pointer_cast<FlatForward>(*discountCurve_)) {
+        // no dates to extract
+    } else {
+        QL_FAIL("Yield curve must be flat forward interpolated");
+    }
+
+    if (ext::shared_ptr<InterpolatedSurvivalProbabilityCurve<LogLinear> > castC1 =
+            ext::dynamic_pointer_cast<InterpolatedSurvivalProbabilityCurve<LogLinear> >(*probability_)) {
+        cDates = castC1->dates();
+    } else if (ext::shared_ptr<InterpolatedHazardRateCurve<BackwardFlat> > castC2 =
+                   ext::dynamic_pointer_cast<InterpolatedHazardRateCurve<BackwardFlat> >(*probability_)) {
+        cDates = castC2->dates();
+    } else if (ext::shared_ptr<FlatHazardRate> castC3 = ext::dynamic_pointer_cast<FlatHazardRate>(*probability_)) {
+        // no dates to extract
+    } else {
+        QL_FAIL("Credit curve must be flat forward interpolated");
+    }
+
+    std::vector<Date> nodes;
+    std::set_union(yDates.begin(), yDates.end(), cDates.begin(), cDates.end(), std::back_inserter(nodes));
+
+    if (nodes.empty()) {
+        nodes.push_back(maturity);
+    }
+    const Real nFix = (numericalFix_ == None ? 1E-50 : 0.0);
+
+    // protection leg pricing (npv is always negative at this stage)
+    Real protectionNpv = 0.0;
+
+    Date d0 = effectiveProtectionStart - 1;
+    Real P0 = discountCurve_->discount(d0);
+    Real Q0 = probability_->survivalProbability(d0);
+    Date d1;
+    std::vector<Date>::const_iterator it = std::upper_bound(nodes.begin(), nodes.end(), effectiveProtectionStart);
+
+    for (; it != nodes.end(); ++it) {
+        if (*it > maturity) {
+            d1 = maturity;
+            it = nodes.end() - 1; // early exit
+        } else {
+            d1 = *it;
+        }
+        Real P1 = discountCurve_->discount(d1);
+        Real Q1 = probability_->survivalProbability(d1);
+
+        Real fhat = std::log(P0) - std::log(P1);
+        Real hhat = std::log(Q0) - std::log(Q1);
+        Real fhphh = fhat + hhat;
+
+        if (fhphh < 1E-4 && numericalFix_ == Taylor) {
+            Real fhphhq = fhphh * fhphh;
+            protectionNpv +=
+                P0 * Q0 * hhat *
+                (1.0 - 0.5 * fhphh + 1.0 / 6.0 * fhphhq - 1.0 / 24.0 * fhphhq * fhphh + 1.0 / 120 * fhphhq * fhphhq);
+        } else {
+            protectionNpv += hhat / (fhphh + nFix) * (P0 * Q0 - P1 * Q1);
+        }
+        d0 = d1;
+        P0 = P1;
+        Q0 = Q1;
+    }
+    protectionNpv *= arguments_.claim->amount(Null<Date>(), arguments_.notional, recoveryRate_);
+
+    results_.defaultLegNPV = protectionNpv;
+
+    // premium leg pricing (npv is always positive at this stage)
+
+    Real premiumNpv = 0.0, defaultAccrualNpv = 0.0;
+    for (auto& i : arguments_.leg) {
+        ext::shared_ptr<FixedRateCoupon> coupon = ext::dynamic_pointer_cast<FixedRateCoupon>(i);
+
+        QL_REQUIRE(coupon->dayCounter() == dc || coupon->dayCounter() == dc1 || coupon->dayCounter() == dc2,
+                   "ISDA engine requires a coupon day counter Act/365Fixed "
+                       << "or Act/360 (" << coupon->dayCounter() << ")");
+
+        // premium coupons
+        if (!i->hasOccurred(effectiveProtectionStart, includeSettlementDateFlows_)) {
+            premiumNpv += coupon->amount() * discountCurve_->discount(coupon->date()) *
+                          probability_->survivalProbability(coupon->date() - 1);
+        }
+
+        // default accruals
+
+        if (!detail::simple_event(coupon->accrualEndDate()).hasOccurred(effectiveProtectionStart, false)) {
+            Date start = std::max<Date>(coupon->accrualStartDate(), effectiveProtectionStart) - 1;
+            Date end = coupon->date() - 1;
+            Real tstart = discountCurve_->timeFromReference(coupon->accrualStartDate() - 1) -
+                          (accrualBias_ == HalfDayBias ? 1.0 / 730.0 : 0.0);
+            std::vector<Date> localNodes;
+            localNodes.push_back(start);
+            // add intermediary nodes, if any
+            if (forwardsInCouponPeriod_ == Piecewise) {
+                std::vector<Date>::const_iterator it0 = std::upper_bound(nodes.begin(), nodes.end(), start);
+                std::vector<Date>::const_iterator it1 = std::lower_bound(nodes.begin(), nodes.end(), end);
+                localNodes.insert(localNodes.end(), it0, it1);
+            }
+            localNodes.push_back(end);
+
+            Real defaultAccrThisNode = 0.;
+            std::vector<Date>::const_iterator node = localNodes.begin();
+            Real t0 = discountCurve_->timeFromReference(*node);
+            Real P0 = discountCurve_->discount(*node);
+            Real Q0 = probability_->survivalProbability(*node);
+
+            for (++node; node != localNodes.end(); ++node) {
+                Real t1 = discountCurve_->timeFromReference(*node);
+                Real P1 = discountCurve_->discount(*node);
+                Real Q1 = probability_->survivalProbability(*node);
+                Real fhat = std::log(P0) - std::log(P1);
+                Real hhat = std::log(Q0) - std::log(Q1);
+                Real fhphh = fhat + hhat;
+                if (fhphh < 1E-4 && numericalFix_ == Taylor) {
+                    // see above, terms up to (f+h)^3 seem more than enough,
+                    // what exactly is implemented in the standard isda C
+                    // code ?
+                    Real fhphhq = fhphh * fhphh;
+                    defaultAccrThisNode +=
+                        hhat * P0 * Q0 *
+                        ((t0 - tstart) * (1.0 - 0.5 * fhphh + 1.0 / 6.0 * fhphhq - 1.0 / 24.0 * fhphhq * fhphh) +
+                         (t1 - t0) * (0.5 - 1.0 / 3.0 * fhphh + 1.0 / 8.0 * fhphhq - 1.0 / 30.0 * fhphhq * fhphh));
+                } else {
+                    defaultAccrThisNode +=
+                        (hhat / (fhphh + nFix)) * ((t1 - t0) * ((P0 * Q0 - P1 * Q1) / (fhphh + nFix) - P1 * Q1) +
+                                                   (t0 - tstart) * (P0 * Q0 - P1 * Q1));
+                }
+
+                t0 = t1;
+                P0 = P1;
+                Q0 = Q1;
+            }
+            defaultAccrualNpv += defaultAccrThisNode * arguments_.notional * coupon->rate() * 365. / 360.;
+        }
+    }
+
+    results_.couponLegNPV = premiumNpv + defaultAccrualNpv;
+
+    // upfront flow npv
+
+    Real upfPVO1 = 0.0;
+    results_.upfrontNPV = 0.0;
+    if (!arguments_.upfrontPayment->hasOccurred(evalDate, includeSettlementDateFlows_)) {
+        upfPVO1 = discountCurve_->discount(arguments_.upfrontPayment->date());
+        if (arguments_.upfrontPayment->amount() != 0.) {
+            results_.upfrontNPV = upfPVO1 * arguments_.upfrontPayment->amount();
+        }
+    }
+
+    results_.accrualRebateNPV = 0.;
+    // NOLINTNEXTLINE(readability-implicit-bool-conversion)
+    if (arguments_.accrualRebate && arguments_.accrualRebate->amount() != 0. &&
+        !arguments_.accrualRebate->hasOccurred(evalDate, includeSettlementDateFlows_)) {
+        results_.accrualRebateNPV =
+            discountCurve_->discount(arguments_.accrualRebate->date()) * arguments_.accrualRebate->amount();
+    }
+
+    Real upfrontSign = Protection::Seller != 0U ? 1.0 : -1.0;
+
+    if (arguments_.side == Protection::Seller) {
+        results_.defaultLegNPV *= -1.0;
+        results_.accrualRebateNPV *= -1.0;
+    } else {
+        results_.couponLegNPV *= -1.0;
+        results_.upfrontNPV *= -1.0;
+    }
+
+    results_.value = results_.defaultLegNPV + results_.couponLegNPV + results_.upfrontNPV + results_.accrualRebateNPV;
+
+    results_.errorEstimate = Null<Real>();
+
+    if (results_.couponLegNPV != 0.0) {
+        results_.fairSpread =
+            -results_.defaultLegNPV * arguments_.spread / (results_.couponLegNPV + results_.accrualRebateNPV);
+    } else {
+        results_.fairSpread = Null<Rate>();
+    }
+
+    Real upfrontSensitivity = upfPVO1 * arguments_.notional;
+    if (upfrontSensitivity != 0.0) {
+        results_.fairUpfront = -upfrontSign *
+                               (results_.defaultLegNPV + results_.couponLegNPV + results_.accrualRebateNPV) /
+                               upfrontSensitivity;
+    } else {
+        results_.fairUpfront = Null<Rate>();
+    }
+
+    static const Rate basisPoint = 1.0e-4;
+
+    if (arguments_.spread != 0.0) {
+        results_.couponLegBPS = results_.couponLegNPV * basisPoint / arguments_.spread;
+    } else {
+        results_.couponLegBPS = Null<Rate>();
+    }
+
+    // NOLINTNEXTLINE(readability-implicit-bool-conversion)
+    if (arguments_.upfront && *arguments_.upfront != 0.0) {
+        results_.upfrontBPS = results_.upfrontNPV * basisPoint / (*arguments_.upfront);
+    } else {
+        results_.upfrontBPS = Null<Rate>();
+    }
+}
+
+} // namespace QuantLib

--- a/QuantExt/qle/pricingengines/isdacdsengine.cpp
+++ b/QuantExt/qle/pricingengines/isdacdsengine.cpp
@@ -37,6 +37,8 @@
 */
 
 #include <qle/pricingengines/isdacdsengine.hpp>
+#include <qle/termstructures/interpolatedhazardratecurve.hpp>
+#include <qle/termstructures/interpolatedsurvivalprobabilitycurve.hpp>
 
 #include <ql/cashflows/fixedratecoupon.hpp>
 #include <ql/instruments/claim.hpp>
@@ -123,11 +125,11 @@ void IsdaCdsEngine::calculate() const {
         QL_FAIL("Yield curve must be flat forward interpolated");
     }
 
-    if (ext::shared_ptr<InterpolatedSurvivalProbabilityCurve<LogLinear> > castC1 =
-            ext::dynamic_pointer_cast<InterpolatedSurvivalProbabilityCurve<LogLinear> >(*probability_)) {
+    if (ext::shared_ptr<QuantExt::InterpolatedSurvivalProbabilityCurve<LogLinear> > castC1 =
+            ext::dynamic_pointer_cast<QuantExt::InterpolatedSurvivalProbabilityCurve<LogLinear> >(*probability_)) {
         cDates = castC1->dates();
-    } else if (ext::shared_ptr<InterpolatedHazardRateCurve<BackwardFlat> > castC2 =
-                   ext::dynamic_pointer_cast<InterpolatedHazardRateCurve<BackwardFlat> >(*probability_)) {
+    } else if (ext::shared_ptr<QuantExt::InterpolatedHazardRateCurve<BackwardFlat> > castC2 =
+                   ext::dynamic_pointer_cast<QuantExt::InterpolatedHazardRateCurve<BackwardFlat> >(*probability_)) {
         cDates = castC2->dates();
     } else if (ext::shared_ptr<FlatHazardRate> castC3 = ext::dynamic_pointer_cast<FlatHazardRate>(*probability_)) {
         // no dates to extract

--- a/QuantExt/qle/pricingengines/isdacdsengine.hpp
+++ b/QuantExt/qle/pricingengines/isdacdsengine.hpp
@@ -1,0 +1,145 @@
+/* -*- mode: c++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*
+ Copyright (C) 2021 Skandinaviska Enskilda Banken AB (publ)
+ All rights reserved.
+
+ This file is part of ORE, a free-software/open-source library
+ for transparent pricing and risk analysis - http://opensourcerisk.org
+
+ ORE is free software: you can redistribute it and/or modify it
+ under the terms of the Modified BSD License.  You should have received a
+ copy of the license along with this program.
+ The license is also available online at <http://opensourcerisk.org>
+
+ This program is distributed on the basis that it will form a useful
+ contribution to risk analytics and model standardisation, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
+*/
+
+/*
+ Copyright (C) 2014 Jose Aparicio
+ Copyright (C) 2014 Peter Caspers
+
+ This file is part of QuantLib, a free-software/open-source library
+ for financial quantitative analysts and developers - http://quantlib.org/
+
+ QuantLib is free software: you can redistribute it and/or modify it
+ under the terms of the QuantLib license.  You should have received a
+ copy of the license along with this program; if not, please email
+ <quantlib-dev@lists.sf.net>. The license is also available online at
+ <http://quantlib.org/license.shtml>.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ FOR A PARTICULAR PURPOSE.  See the license for more details.
+*/
+
+/*! \file isdacdsengine.hpp
+    \brief ISDA engine for credit default swaps
+
+    This is a copy of the class QuantLib::IsdaCdsEngine with
+    one minor change. The class QuantExt::CreditDefaultSwap expands
+    on QL's CDS instrument in regards to the enum ProtectionPaymentTime. 
+    Because of this, we have to copy the ISDA engine's implementation
+    and alter one of the argument requirements to check for 
+    ProtectionPaymentTime::atDefault rather than paysAtDefaultTime==true. 
+*/
+
+#ifndef quantext_isda_cds_engine_hpp
+#define quantext_isda_cds_engine_hpp
+
+#include <qle/instruments/creditdefaultswap.hpp>
+#include <ql/termstructures/defaulttermstructure.hpp>
+#include <ql/termstructures/yieldtermstructure.hpp>
+
+namespace QuantExt {
+using namespace QuantLib;
+
+/*! References:
+
+    [1] The Pricing and Risk Management of Credit Default Swaps, with a
+        Focus on the ISDA Model,
+        OpenGamma Quantitative Research, Version as of 15-Oct-2013
+
+    [2] ISDA CDS Standard Model Proposed Numerical Fix \ Thursday,
+        November 15, 2012, Markit
+
+    [3] Markit Interest Rate Curve XML Specifications,
+        Version 1.16, Tuesday, 15 October 2013
+
+*/
+
+class IsdaCdsEngine : public CreditDefaultSwap::engine {
+
+public:
+    /*! According to [1] the settings for the flags
+        AccrualBias / ForwardsInCouponPeriod corresponding
+        to the standard model implementation C code are
+
+        prior 1.8.2    HalfDayBias / Flat
+        1.8.2          NoBias / Flat
+
+        The theoretical correct setting would be NoBias / Piecewise
+
+        Todo: Clarify in which version of the standard model
+        implementation C code the numerical problem of zero denominators
+        is solved and how exactly.
+    */
+
+    enum NumericalFix {
+        None,  // as in [1] footnote 26 (i.e. 10^{-50} is added to
+               // denominators $f_i+h_i$$)
+        Taylor // as in [2] i.e. for $f_i+h_i < 10^{-4}$ a Taylor expansion
+               // is used to avoid zero denominators
+    };
+
+    enum AccrualBias {
+        HalfDayBias, // as in [1] formula (50), second (error) term is
+                     // included
+        NoBias       // as in [1], but second term in formula (50) is not included
+    };
+
+    enum ForwardsInCouponPeriod {
+        Flat,     // as in [1], formula (52), second (error) term is included
+        Piecewise // as in [1], but second term in formula (52) is not
+                  // included
+    };
+
+    /*! Constructor where the client code is responsible for providing a
+        default curve and an interest rate curve compliant with the ISDA
+        specifications.
+
+        To be precisely consistent with the ISDA specification
+            static bool IborCoupon::usingAtParCoupons();
+        must be true. This is not checked in order not to
+        kill the engine completely in this case.
+
+        Furthermore, the ibor index in the swap rate helpers should not
+        provide the evaluation date's fixing.
+    */
+
+    IsdaCdsEngine(Handle<DefaultProbabilityTermStructure> probability, Real recoveryRate,
+                  Handle<YieldTermStructure> discountCurve,
+                  const boost::optional<bool>& includeSettlementDateFlows = boost::none,
+                  NumericalFix numericalFix = Taylor, AccrualBias accrualBias = HalfDayBias,
+                  ForwardsInCouponPeriod forwardsInCouponPeriod = Piecewise);
+
+    Handle<YieldTermStructure> isdaRateCurve() const { return discountCurve_; }
+    Handle<DefaultProbabilityTermStructure> isdaCreditCurve() const { return probability_; }
+
+    void calculate() const override;
+
+private:
+    Handle<DefaultProbabilityTermStructure> probability_;
+    const Real recoveryRate_;
+    Handle<YieldTermStructure> discountCurve_;
+    const boost::optional<bool> includeSettlementDateFlows_;
+    const NumericalFix numericalFix_;
+    const AccrualBias accrualBias_;
+    const ForwardsInCouponPeriod forwardsInCouponPeriod_;
+};
+} // namespace QuantExt
+
+#endif


### PR DESCRIPTION
We wanted to benchmark against the Isda CDS engine available in QuantLib and have thus mapped it for use within ORE. The engine's enum parameters have been exposed for toggling inside the pricing engine config. I mention some issues that the PR presents in #91, and this PR serves to provide a partial resolution to it until the QuantExt `CreditDefaultSwap` instrument is eventually merged with QL. 

Documentation: We added a sample engine config to _Examples/Input/pricingengine.xml_, illustrating optional and default engine parameters. 

Test coverage: We added a test to verify that the new engine builds without issues when linked and that it can price a trade with made-up market data. Other than that, we rely on the QL tests being sufficient to validate the pricing. 

Remark for code review: The files _isdacdsengine.*pp_ that were copied into QuantExt from QuantLib perhaps don't need a proper review at this stage, I'd rather leave that for later if they're to be migrated back over to QuantLib. 

Best regards,
Fredrik