### PR TITLE
Hotfix: Minor corrections for equity proxy volatility surfaces

### DIFF
--- a/OREData/ored/configuration/equityvolcurveconfig.hpp
+++ b/OREData/ored/configuration/equityvolcurveconfig.hpp
@@ -75,7 +75,7 @@ public:
     const string& proxySurface() const { return proxySurface_; }
     const string quoteStem() const;
     void populateQuotes();
-    bool isProxySurface() { return !proxySurface_.empty(); };
+    bool isProxySurface() const { return !proxySurface_.empty(); };
     OneDimSolverConfig solverConfig() const;
     const boost::optional<bool>& preferOutOfTheMoney() const {
         return preferOutOfTheMoney_;

--- a/QuantExt/qle/termstructures/equityblackvolsurfaceproxy.hpp
+++ b/QuantExt/qle/termstructures/equityblackvolsurfaceproxy.hpp
@@ -16,8 +16,8 @@
  FITNESS FOR A PARTICULAR PURPOSE. See the license for more details.
 */
 
-/*! \file qle/termstructures/blackvolsurfacewithatm.hpp
-    \brief Wrapper class for a BlackVolTermStructure that easily exposes ATM vols.
+/*! \file qle/termstructures/equityblackvolsurfaceproxy.hpp
+    \brief Wrapper class for a BlackVolTermStructure when using proxy vols.
     \ingroup termstructures
 */
 

--- a/QuantExt/qle/termstructures/equityblackvolsurfaceproxy.hpp
+++ b/QuantExt/qle/termstructures/equityblackvolsurfaceproxy.hpp
@@ -21,8 +21,8 @@
     \ingroup termstructures
 */
 
-#ifndef quantext_blackvolsurfacewithatm_hpp
-#define quantext_blackvolsurfacewithatm_hpp
+#ifndef quantext_equity_black_volatility_surface_proxy_hpp
+#define quantext_equity_black_volatility_surface_proxy_hpp
 
 #include <boost/shared_ptr.hpp>
 #include <ql/termstructures/volatility/equityfx/blackvoltermstructure.hpp>


### PR DESCRIPTION
This fixes three minor issues relating to equity proxy vols:
- The include guard of the class in _equityblackvolsurfaceproxy.hpp_ no longer duplicates/redefines the one from _blackvolsurfacewithatm.hpp_, to avoid any problems.
- The docstring was updated to reflect the correct file/class.
- The inspector for proxy vols was marked as `const`.