### PR TITLE
Inflation curve stuff

### DIFF
--- a/OREAnalytics/orea/app/marketcalibrationreport.cpp
+++ b/OREAnalytics/orea/app/marketcalibrationreport.cpp
@@ -261,6 +261,7 @@ void MarketCalibrationReport::addInflationCurveImpl(
             addRowReport(type, id, "time", key1, "", "", z->times.at(i));
             addRowReport(type, id, "zeroRate", key1, "", "", z->zeroRates.at(i));
             addRowReport(type, id, "cpi", key1, "", "", z->forwardCpis.at(i));
+            addRowReport(type, id, "unSeasonalizedCpi", key1, "", "", z->unSeasonalizedForwardCpis.at(i));
         }
     }
 

--- a/OREAnalytics/orea/app/marketcalibrationreport.cpp
+++ b/OREAnalytics/orea/app/marketcalibrationreport.cpp
@@ -260,6 +260,7 @@ void MarketCalibrationReport::addInflationCurveImpl(
             std::string key1 = ore::data::to_string(z->pillarDates[i]);
             addRowReport(type, id, "time", key1, "", "", z->times.at(i));
             addRowReport(type, id, "zeroRate", key1, "", "", z->zeroRates.at(i));
+            addRowReport(type, id, "unSeasonalizedZeroRate", key1, "", "", z->unSeasonalizedZeroRates.at(i));
             addRowReport(type, id, "cpi", key1, "", "", z->forwardCpis.at(i));
             addRowReport(type, id, "unSeasonalizedCpi", key1, "", "", z->unSeasonalizedForwardCpis.at(i));
         }

--- a/OREAnalytics/orea/app/marketdataloader.cpp
+++ b/OREAnalytics/orea/app/marketdataloader.cpp
@@ -188,7 +188,7 @@ void MarketDataLoader::populateFixings(
         amendInflationFixingDates(fixings_);
     }
 
-    if (fixings_.size() > 0 && impl_)
+    if (impl_)
         impl()->retrieveFixings(loader_, fixings_, lastAvailableFixingLookupMap);
 
     applyFixings(loader_->loadFixings());

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -218,7 +218,7 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
                     seasonality);
                 auto yoyCurve = QuantLib::ext::dynamic_pointer_cast<YoYInflationTermStructure>(curve_);
                 Handle<YoYInflationTermStructure> yoyHandle(yoyCurve);
-                auto yoyIndex = QuantLib::ext::make_shared<QuantExt::YoYInflationIndexWrapper>(index, yoyHandle);
+                auto yoyIndex = QuantLib::ext::make_shared<QuantExt::YoYInflationIndexWrapper>(index, yoyHandle, yoyInstruments.front()->earliestDate());
                 for (Size i = 0; i < yoyPillarDates.size(); i++) {
                     WLOG("Date: " << yoyPillarDates[i]
                                   << ", forwardCpi: " << yoyIndex->forwardCpi(yoyPillarDates[i], true) << " ("

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -221,7 +221,7 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
                 auto yoyIndex = QuantLib::ext::make_shared<QuantExt::YoYInflationIndexWrapper>(index, yoyHandle, yoyInstruments.front()->earliestDate());
                 for (Size i = 0; i < yoyPillarDates.size(); i++) {
                     WLOG("Date: " << yoyPillarDates[i]
-                                  << ", forwardCpi: " << yoyIndex->forwardCpi(yoyPillarDates[i], true) << " ("
+                                  << ", forwardCpi: " << yoyIndex->forwardCpi(yoyPillarDates[i], true) << " (Seasonalized "
                                   << yoyIndex->forwardCpi(yoyPillarDates[i], false) << ")");
                 }
                 for (Size i = 0; i < yoyInstruments.size(); i++) {

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -213,7 +213,7 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
 
 
 
-                auto baseFixing = index->fixing(baseDate, true);
+                auto baseFixing = index->fixing(baseDate);
                 if (config->interpolationMethod().empty() || config->interpolationMethod() == "Linear"){
                 
                     curve_ = QuantLib::ext::make_shared<QuantExt::PiecewiseCPIInflationCurve<Linear>>(

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -360,8 +360,8 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
                 for (Size i = 0; i < pillarDates.size(); ++i) {
                     calInfo->pillarDates.push_back(pillarDates[i]);
                     calInfo->zeroRates.push_back(zcCurve->zeroRate(pillarDates[i], 0 * Days));
-                    calInfo->times.push_back(zcCurve->timeFromReference(pillarDates[i]));
                     calInfo->unSeasonalizedZeroRates.push_back(zcCurve->zeroRate(pillarDates[i], 0 * Days, false, false, false));
+                    calInfo->times.push_back(inflationYearFraction(curve_->frequency(), false, curve_->dayCounter(), curve_->baseDate(), pillarDates[i]));
                     Real cpi = 0.0;
                     Real unSeasonalizedCpi = 0.0;
                     try {

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -361,6 +361,7 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
                     calInfo->pillarDates.push_back(pillarDates[i]);
                     calInfo->zeroRates.push_back(zcCurve->zeroRate(pillarDates[i], 0 * Days));
                     calInfo->times.push_back(zcCurve->timeFromReference(pillarDates[i]));
+                    calInfo->unSeasonalizedZeroRates.push_back(zcCurve->zeroRate(pillarDates[i], 0 * Days, false, false, false));
                     Real cpi = 0.0;
                     Real unSeasonalizedCpi = 0.0;
                     try {

--- a/OREData/ored/marketdata/inflationcurve.cpp
+++ b/OREData/ored/marketdata/inflationcurve.cpp
@@ -362,11 +362,14 @@ InflationCurve::InflationCurve(Date asof, InflationCurveSpec spec, const Loader&
                     calInfo->zeroRates.push_back(zcCurve->zeroRate(pillarDates[i], 0 * Days));
                     calInfo->times.push_back(zcCurve->timeFromReference(pillarDates[i]));
                     Real cpi = 0.0;
+                    Real unSeasonalizedCpi = 0.0;
                     try {
                         cpi = zcIndex->fixing(pillarDates[i]);
+                        unSeasonalizedCpi = zcIndex->fixing(pillarDates[i], false, false);
                     } catch (...) {
                     }
                     calInfo->forwardCpis.push_back(cpi);
+                    calInfo->unSeasonalizedForwardCpis.push_back(unSeasonalizedCpi);
                 }
                 calibrationInfo_ = calInfo;
             }

--- a/OREData/ored/marketdata/todaysmarketcalibrationinfo.hpp
+++ b/OREData/ored/marketdata/todaysmarketcalibrationinfo.hpp
@@ -85,6 +85,7 @@ struct ZeroInflationCurveCalibrationInfo : public InflationCurveCalibrationInfo 
     double baseCpi = 0.0;
     std::vector<double> zeroRates;
     std::vector<double> forwardCpis;
+    std::vector<double> unSeasonalizedForwardCpis;
 };
 
 struct YoYInflationCurveCalibrationInfo : public InflationCurveCalibrationInfo {

--- a/OREData/ored/marketdata/todaysmarketcalibrationinfo.hpp
+++ b/OREData/ored/marketdata/todaysmarketcalibrationinfo.hpp
@@ -84,6 +84,7 @@ struct InflationCurveCalibrationInfo {
 struct ZeroInflationCurveCalibrationInfo : public InflationCurveCalibrationInfo {
     double baseCpi = 0.0;
     std::vector<double> zeroRates;
+    std::vector<double> unSeasonalizedZeroRates;
     std::vector<double> forwardCpis;
     std::vector<double> unSeasonalizedForwardCpis;
 };

--- a/QuantExt/qle/indexes/inflationindexwrapper.cpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.cpp
@@ -34,15 +34,15 @@ Rate ZeroInflationIndexWrapper::fixing(const Date& fixingDate, bool /*forecastTo
 }
 
 YoYInflationIndexWrapper::YoYInflationIndexWrapper(const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex,
-                                                   const Handle<YoYInflationTermStructure>& ts)
-    : YoYInflationIndex(zeroIndex, ts), zeroIndex_(zeroIndex) {
+                                                   const Handle<YoYInflationTermStructure>& ts, const Date& firstPillarDate)
+    : YoYInflationIndex(zeroIndex, ts), zeroIndex_(zeroIndex), firstPillarDate_(firstPillarDate) {
     registerWith(zeroIndex_);
 }
 
 YoYInflationIndexWrapper::YoYInflationIndexWrapper(const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex,
                                                    const bool interpolated, const Handle<YoYInflationTermStructure>& ts)
     : YoYInflationIndex(zeroIndex, interpolated, ts),
-      zeroIndex_(zeroIndex) {
+      zeroIndex_(zeroIndex), firstPillarDate_(Date()) {
     registerWith(zeroIndex_);
 }
 

--- a/QuantExt/qle/indexes/inflationindexwrapper.cpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.cpp
@@ -87,4 +87,13 @@ Real YoYInflationIndexWrapper::forwardCpi(const Date& fixingDate, bool adjustFor
     return pastFixing * (1 + yoyRateDeseasonalized);
 }
 
+Rate YoYInflationIndexWrapper::impliedZeroRate(const Date& to, const DayCounter& dc) const {
+    Date baseDate = yoyInflationTermStructure()->baseDate();
+    Real baseFixing = CPI::laggedFixing(zeroIndex_, baseDate, 0 * Days, CPI::Flat);
+    Real toCpi = forwardCpi(to, false);
+    Time t = dc.yearFraction(baseDate, to);
+    t = t == 0 ? 1 : t;
+    return std::pow(toCpi / baseFixing, 1.0 / t) - 1;
+}
+
 } // namespace QuantExt

--- a/QuantExt/qle/indexes/inflationindexwrapper.cpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.cpp
@@ -66,7 +66,7 @@ Real YoYInflationIndexWrapper::forecastFixing(const Date& fixingDate) const {
     return (f1 - f0) / f0;
 }
 
-Real YoYInflationIndexWrapper::forwardCpi(const Date& fixingDate, bool adjustForSeasonality) const {
+Real YoYInflationIndexWrapper::forwardCpi(const Date& fixingDate, bool removeSeasonality) const {
     Date fixingDateMinusOneYear = fixingDate - 1 * Years;
     Real pastFixing;
     if (needsForecast(fixingDateMinusOneYear)) {
@@ -79,7 +79,8 @@ Real YoYInflationIndexWrapper::forwardCpi(const Date& fixingDate, bool adjustFor
     }
 
     Rate yoyRate = fixing(fixingDate);
-    if (!adjustForSeasonality) {
+    if (!removeSeasonality) {
+        // check if date is after baseDate but before any helpers 
         return pastFixing * (1 + yoyRate);
     }
     Handle<YoYInflationTermStructure> ts = yoyInflationTermStructure();

--- a/QuantExt/qle/indexes/inflationindexwrapper.hpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.hpp
@@ -64,7 +64,8 @@ private:
 class YoYInflationIndexWrapper : public YoYInflationIndex {
 public:
     YoYInflationIndexWrapper(const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex,
-                             const Handle<YoYInflationTermStructure>& ts = Handle<YoYInflationTermStructure>());
+                             const Handle<YoYInflationTermStructure>& ts = Handle<YoYInflationTermStructure>(),
+                             const Date& firstPillarDate = Date());
 
     [[deprecated]]
     YoYInflationIndexWrapper(const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex, const bool interpolated,
@@ -79,6 +80,7 @@ public:
 private:
     Rate forecastFixing(const Date& fixingDate) const;
     const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex_;
+    const Date& firstPillarDate_;
 };
 
 } // namespace QuantExt

--- a/QuantExt/qle/indexes/inflationindexwrapper.hpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.hpp
@@ -73,6 +73,7 @@ public:
     /*! \warning the forecastTodaysFixing parameter (required by the Index interface) is currently ignored. */
     Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
     const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex() const { return zeroIndex_; }
+    Real forwardCpi(const Date& fixingDate, bool adjustForSeasonality) const;
 
 private:
     Rate forecastFixing(const Date& fixingDate) const;

--- a/QuantExt/qle/indexes/inflationindexwrapper.hpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.hpp
@@ -73,7 +73,7 @@ public:
     /*! \warning the forecastTodaysFixing parameter (required by the Index interface) is currently ignored. */
     Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
     const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex() const { return zeroIndex_; }
-    Real forwardCpi(const Date& fixingDate, bool adjustForSeasonality) const;
+    Real forwardCpi(const Date& fixingDate, bool removeSeasonality) const;
     Rate impliedZeroRate(const Date& to, const DayCounter& dc) const;
 
 private:

--- a/QuantExt/qle/indexes/inflationindexwrapper.hpp
+++ b/QuantExt/qle/indexes/inflationindexwrapper.hpp
@@ -74,6 +74,7 @@ public:
     Rate fixing(const Date& fixingDate, bool forecastTodaysFixing = false) const override;
     const QuantLib::ext::shared_ptr<ZeroInflationIndex> zeroIndex() const { return zeroIndex_; }
     Real forwardCpi(const Date& fixingDate, bool adjustForSeasonality) const;
+    Rate impliedZeroRate(const Date& to, const DayCounter& dc) const;
 
 private:
     Rate forecastFixing(const Date& fixingDate) const;


### PR DESCRIPTION
Add unseasonalized CPI values for zero coupon inflation curves to todays market calibration. [These](https://github.com/Model-Validation/QuantLib/pull/25) changes to our QL dev-13 branch are required for it to work.