### PR TITLE
Fixed overnight calendar ois

### DIFF
--- a/OREData/ored/configuration/conventions.cpp
+++ b/OREData/ored/configuration/conventions.cpp
@@ -296,11 +296,11 @@ OisConvention::OisConvention(const string& id, const string& spotLag, const stri
                              const string& fixedDayCounter, const string& fixedCalendar, const string& paymentLag,
                              const string& eom, const string& fixedFrequency, const string& fixedConvention,
                              const string& fixedPaymentConvention, const string& rule, const string& paymentCal,
-                             const string& rateCutoff)
+                             const string& rateCutoff, const string& overnightCalendar)
     : Convention(id, Type::OIS), strSpotLag_(spotLag), strIndex_(index), strFixedDayCounter_(fixedDayCounter),
       strFixedCalendar_(fixedCalendar), strPaymentLag_(paymentLag), strEom_(eom), strFixedFrequency_(fixedFrequency),
       strFixedConvention_(fixedConvention), strFixedPaymentConvention_(fixedPaymentConvention), strRule_(rule),
-      strPaymentCal_(paymentCal), strRateCutoff_(rateCutoff) {
+      strPaymentCal_(paymentCal), strRateCutoff_(rateCutoff), strOvernightCalendar_(overnightCalendar) {
     build();
 }
 
@@ -318,6 +318,7 @@ void OisConvention::build() {
     rule_ = strRule_.empty() ? DateGeneration::Backward : parseDateGenerationRule(strRule_);
     paymentCal_ = strPaymentCal_.empty() ? Calendar() : parseCalendar(strPaymentCal_);
     rateCutoff_ = strRateCutoff_.empty() ? 0 : lexical_cast<Natural>(strRateCutoff_);
+    overnightCalendar_ = strOvernightCalendar_.empty() ? Calendar() : parseCalendar(strOvernightCalendar_);
 
 }
 
@@ -341,6 +342,7 @@ void OisConvention::fromXML(XMLNode* node) {
     strRule_ = XMLUtils::getChildValue(node, "Rule", false);
     strPaymentCal_ = XMLUtils::getChildValue(node, "PaymentCalendar", false);
     strRateCutoff_ = XMLUtils::getChildValue(node, "RateCutoff", false);
+    strOvernightCalendar_ = XMLUtils::getChildValue(node, "OvernightCalendar", false);
 
     build();
 }
@@ -370,6 +372,8 @@ XMLNode* OisConvention::toXML(XMLDocument& doc) const {
         XMLUtils::addChild(doc, node, "PaymentCalendar", strPaymentCal_);
     if (!strRateCutoff_.empty())
         XMLUtils::addChild(doc, node, "RateCutoff", strRateCutoff_);
+    if (!strOvernightCalendar_.empty())
+        XMLUtils::addChild(doc, node, "OvernightCalendar", strOvernightCalendar_);
 
     return node;
 }

--- a/OREData/ored/configuration/conventions.hpp
+++ b/OREData/ored/configuration/conventions.hpp
@@ -394,7 +394,8 @@ public:
                   const string& fixedFrequency = "", const string& fixedConvention = "",
                   const string& fixedPaymentConvention = "", const string& rule = "",
                   const std::string& paymentCalendar = "",
-                  const std::string& rateCutoff = "");
+                  const std::string& rateCutoff = "",
+                  const std::string& overnightCalendar = "");
     //@}
 
     //! \name Inspectors
@@ -413,6 +414,7 @@ public:
     DateGeneration::Rule rule() const { return rule_; }
     QuantLib::Calendar paymentCalendar() const { return paymentCal_; }
     Natural rateCutoff() const { return rateCutoff_; }
+    const Calendar& overnightCalendar() const { return overnightCalendar_; }
     //@}
 
     //! \name Serialisation
@@ -434,6 +436,7 @@ private:
     DateGeneration::Rule rule_;
     QuantLib::Calendar paymentCal_;
     Natural rateCutoff_;
+    Calendar overnightCalendar_;
 
     // Strings to store the inputs
     string strSpotLag_;
@@ -448,6 +451,7 @@ private:
     string strRule_;
     std::string strPaymentCal_;
     string strRateCutoff_;
+    string strOvernightCalendar_;
 };
 
 //! Container for storing Ibor Index conventions

--- a/OREData/ored/marketdata/yieldcurve.cpp
+++ b/OREData/ored/marketdata/yieldcurve.cpp
@@ -2724,7 +2724,7 @@ void YieldCurve::addOISs(const std::size_t index, const QuantLib::ext::shared_pt
                         oisConvention->eom(), oisConvention->fixedFrequency(), oisConvention->fixedConvention(),
                         oisConvention->fixedPaymentConvention(), oisConvention->rule(), discountCurve_[index],
                         discountCurveGiven_[index], true, pillarChoice(segment->pillarChoice()), Date(),
-                        oisConvention->paymentCalendar());
+                        oisConvention->paymentCalendar(), oisConvention->overnightCalendar());
                     instruments.push_back(
                         {oisHelper, mainPillarDate(segment->pillarChoice(), oisHelper->pillarDate()),
                          additionalPillarDates(segment->pillarChoice(), oisHelper->earliestDate()), "OIS",

--- a/QuantExt/qle/termstructures/oisratehelper.cpp
+++ b/QuantExt/qle/termstructures/oisratehelper.cpp
@@ -32,13 +32,14 @@ OISRateHelper::OISRateHelper(Natural settlementDays, const Period& swapTenor, co
                              BusinessDayConvention paymentAdjustment, DateGeneration::Rule rule,
                              const Handle<YieldTermStructure>& discountingCurve, const bool discountCurveGiven,
                              bool telescopicValueDates, Pillar::Choice pillar, Date customPillarDate,
-                             const Calendar& paymentCalendar)
+                             const Calendar& paymentCalendar, const Calendar& overnightCalendar)
     : RelativeDateRateHelper(fixedRate), settlementDays_(settlementDays), swapTenor_(swapTenor),
       overnightIndex_(overnightIndex), onIndexGiven_(onIndexGiven), fixedDayCounter_(fixedDayCounter),
       fixedCalendar_(fixedCalendar), paymentLag_(paymentLag), endOfMonth_(endOfMonth),
       paymentFrequency_(paymentFrequency), fixedConvention_(fixedConvention), paymentAdjustment_(paymentAdjustment),
-      rule_(rule), paymentCalendar_(paymentCalendar), discountHandle_(discountingCurve),
-      discountCurveGiven_(discountCurveGiven), telescopicValueDates_(telescopicValueDates), pillarChoice_(pillar) {
+      rule_(rule), paymentCalendar_(paymentCalendar), overnightCalendar_(overnightCalendar),
+      discountHandle_(discountingCurve), discountCurveGiven_(discountCurveGiven),
+      telescopicValueDates_(telescopicValueDates), pillarChoice_(pillar) {
 
     pillarDate_ = customPillarDate;
 
@@ -59,6 +60,7 @@ void OISRateHelper::initializeDates() {
 
     Calendar paymentCalendar = paymentCalendar_.empty() ? overnightIndex_->fixingCalendar() : paymentCalendar_;
     Calendar fixedCalendar = fixedCalendar_.empty() ? overnightIndex_->fixingCalendar() : fixedCalendar_;
+    Calendar overnightCalendar = overnightCalendar_.empty() ? overnightIndex_->fixingCalendar() : paymentCalendar_;
 
     swap_ = MakeOIS(swapTenor_, overnightIndex_, quote().empty() || !quote()->isValid() ? 0.0 : quote()->value())
                 .withSettlementDays(settlementDays_)
@@ -71,7 +73,8 @@ void OISRateHelper::initializeDates() {
                 .withPaymentLag(paymentLag_)
                 .withDiscountingTermStructure(discountRelinkableHandle_)
                 .withTelescopicValueDates(telescopicValueDates_)
-                .withFixedLegCalendar(fixedCalendar);
+                .withFixedLegCalendar(fixedCalendar)
+                .withOvernightLegCalendar(overnightCalendar);
     // TODO: patch QL?
     //.withFixedAccrualConvention(fixedConvention_)
 

--- a/QuantExt/qle/termstructures/oisratehelper.cpp
+++ b/QuantExt/qle/termstructures/oisratehelper.cpp
@@ -58,6 +58,7 @@ OISRateHelper::OISRateHelper(Natural settlementDays, const Period& swapTenor, co
 void OISRateHelper::initializeDates() {
 
     Calendar paymentCalendar = paymentCalendar_.empty() ? overnightIndex_->fixingCalendar() : paymentCalendar_;
+    Calendar fixedCalendar = fixedCalendar_.empty() ? overnightIndex_->fixingCalendar() : fixedCalendar_;
 
     swap_ = MakeOIS(swapTenor_, overnightIndex_, quote().empty() || !quote()->isValid() ? 0.0 : quote()->value())
                 .withSettlementDays(settlementDays_)
@@ -69,10 +70,10 @@ void OISRateHelper::initializeDates() {
                 .withPaymentAdjustment(paymentAdjustment_)
                 .withPaymentLag(paymentLag_)
                 .withDiscountingTermStructure(discountRelinkableHandle_)
-                .withTelescopicValueDates(telescopicValueDates_);
+                .withTelescopicValueDates(telescopicValueDates_)
+                .withFixedLegCalendar(fixedCalendar);
     // TODO: patch QL?
     //.withFixedAccrualConvention(fixedConvention_)
-    //..withFixedCalendar(fixedCalendar_)
 
     earliestDate_ = swap_->startDate();
     maturityDate_ = swap_->maturityDate();

--- a/QuantExt/qle/termstructures/oisratehelper.hpp
+++ b/QuantExt/qle/termstructures/oisratehelper.hpp
@@ -45,7 +45,7 @@ public:
                   const Handle<YieldTermStructure>& discountingCurve = Handle<YieldTermStructure>(),
                   bool discountCurveGiven = false, bool telescopicValueDates = false,
                   Pillar::Choice pillar = Pillar::LastRelevantDate, Date customPillarDate = Date(),
-                  const Calendar& paymentCalendar = Calendar());
+                  const Calendar& paymentCalendar = Calendar(), const Calendar& overnightCalendar = Calendar());
     //! \name RateHelper interface
     //@{
     Real impliedQuote() const override;
@@ -75,6 +75,7 @@ protected:
     BusinessDayConvention paymentAdjustment_;
     DateGeneration::Rule rule_;
     Calendar paymentCalendar_;
+    Calendar overnightCalendar_;
 
     QuantLib::ext::shared_ptr<OvernightIndexedSwap> swap_;
     RelinkableHandle<YieldTermStructure> termStructureHandle_;

--- a/xsd/conventions.xsd
+++ b/xsd/conventions.xsd
@@ -108,6 +108,7 @@
       <xs:element type="dateRule" name="Rule" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:string" name="PaymentCalendar" minOccurs="0" maxOccurs="1"/>
       <xs:element type="xs:integer" name="RateCutoff" minOccurs="0" maxOccurs="1"/>
+      <xs:element type="xs:string" name="OvernightCalendar" minOccurs="0" maxOccurs="1"/>
     </xs:all>
   </xs:complexType>
 


### PR DESCRIPTION
~EDIT: Change this or make a new PR where one creates the QL version of OISRateHelper instead of the QuantExt...~
EDIT: ORE supports projecting floating rates with a different curve (ProjectionCurve in OIS segment) which is not supported in QuantLib, so I think ill just merge this

Start using the fixed calendar that was previously just disregarded when the underlying OIS was created. Additionally, add possibility to send in OvernightCalendar in OIS convention and extend the QuantExt version of OISRateHelper to support it. Hopefully ORE will start using QuantLibs version of OIS in the curve building, so this change might not be relevant quite soon.