### PR TITLE
Handle missing base discount curve and log once

### DIFF
--- a/OREData/ored/portfolio/cashflowutils.cpp
+++ b/OREData/ored/portfolio/cashflowutils.cpp
@@ -23,6 +23,7 @@
 
 #include <ored/portfolio/cashflowutils.hpp>
 #include <ored/utilities/indexnametranslator.hpp>
+#include <ored/utilities/log.hpp>
 #include <ored/utilities/to_string.hpp>
 
 #include <qle/cashflows/averageonindexedcoupon.hpp>
@@ -62,6 +63,7 @@ void populateReportDataFromAdditionalResults(std::vector<TradeCashflowReportData
                                              const std::string& configuration, const bool includePastCashflows) {
 
     Date asof = Settings::instance().evaluationDate();
+    bool missingBaseDiscountCurveLogged = false;
 
     // ensures all cashFlowResults from composite trades are being accounted for
     auto lower = addResults.lower_bound("cashFlowResults");
@@ -107,10 +109,20 @@ void populateReportDataFromAdditionalResults(std::vector<TradeCashflowReportData
                     specificDiscountCurve.empty() ? market->discountCurve(ccy, configuration) : specificDiscountCurve;
                 discountFactor = cf.payDate < asof ? 0.0 : discountCurve->discount(cf.payDate);
             }
-            if (ccy != baseCurrency) {                
-                auto baseDiscountCurve = specificDiscountCurve.empty() ? market->discountCurve(baseCurrency, configuration) : specificDiscountCurve;
-                discountFactorBase = cf.payDate < asof ? 0.0 : baseDiscountCurve->discount(cf.payDate);
-            } 
+            if (ccy != baseCurrency && cf.payDate != Null<Date>()) {
+                try {
+                    auto baseDiscountCurve =
+                        specificDiscountCurve.empty() ? market->discountCurve(baseCurrency, configuration) : specificDiscountCurve;
+                    discountFactorBase = cf.payDate < asof ? 0.0 : baseDiscountCurve->discount(cf.payDate);
+                } catch (std::exception& e) {
+                    if (!missingBaseDiscountCurveLogged) {
+                        DLOG("Could not retrieve base discount curve for cashflow report (base currency "
+                             << baseCurrency << ", configuration " << configuration
+                             << "). DiscountFactor(Base) will be left null. Details: " << e.what());
+                        missingBaseDiscountCurveLogged = true;
+                    }
+                }
+            }
             if (cf.presentValue != Null<Real>()) {
                 presentValue = cf.presentValue * multiplier;
             } else if (effectiveAmount != Null<Real>() && discountFactor != Null<Real>()) {

--- a/OREData/ored/portfolio/trade.cpp
+++ b/OREData/ored/portfolio/trade.cpp
@@ -19,6 +19,7 @@
 #include <ored/portfolio/structuredtradewarning.hpp>
 #include <ored/portfolio/trade.hpp>
 #include <ored/utilities/indexnametranslator.hpp>
+#include <ored/utilities/log.hpp>
 #include <ored/utilities/marketdata.hpp>
 #include <ored/utilities/to_string.hpp>
 #include <ored/portfolio/cashflowutils.hpp>
@@ -449,6 +450,7 @@ std::vector<TradeCashflowReportData> Trade::cashflows(const std::string& baseCur
     // add cashflows from trade legs, if no cashflows were added so far or if a leg is marked as mandatory for cashflows
 
     bool haveEngineCashflows = !result.empty();
+    bool missingBaseDiscountCurveLogged = false;
     for (size_t i = 0; i < legs().size(); i++) {
         Trade::LegCashflowInclusion cashflowInclusion = Trade::LegCashflowInclusion::IfNoEngineCashflows;
         if (auto incl = legCashflowInclusion().find(i); incl != legCashflowInclusion().end()) {
@@ -465,10 +467,20 @@ std::vector<TradeCashflowReportData> Trade::cashflows(const std::string& baseCur
         string ccy = legCurrencies()[i];
 
         Handle<YieldTermStructure> discountCurve = specificDiscountCurve;
-        if (discountCurve.empty()) 
+        if (discountCurve.empty())
             discountCurve = market->discountCurve(ccy, configuration);
-            
-        Handle<YieldTermStructure> baseDiscountCurve = market->discountCurve(baseCurrency, configuration);
+
+        QuantLib::ext::shared_ptr<YieldTermStructure> baseDiscountCurve;
+        try {
+            baseDiscountCurve = *market->discountCurve(baseCurrency, configuration);
+        } catch (std::exception& e) {
+            if (!missingBaseDiscountCurveLogged) {
+                DLOG("Could not retrieve base discount curve for cashflow report (base currency "
+                     << baseCurrency << ", configuration " << configuration
+                     << "). Base discount factor column will be left null where required. Details: " << e.what());
+                missingBaseDiscountCurveLogged = true;
+            }
+        }
 
         auto fxRateCcyBase = market->fxRate(npvCurrency_ + baseCurrency, configuration)->value();
         auto fxRateLocalCcy = market->fxRate(ccy + npvCurrency_, configuration)->value();
@@ -487,7 +499,7 @@ std::vector<TradeCashflowReportData> Trade::cashflows(const std::string& baseCur
                     [&market, &configuration](const std::string qualifier) {
                         return *market->capFloorVol(qualifier, configuration);
                     },
-                    std::string(), Null<Real>(), *baseDiscountCurve));
+                    std::string(), Null<Real>(), baseDiscountCurve));
                 result.back().cashflowNo = j + 1;
                 result.back().legNo = i + legNoOffset;
             }


### PR DESCRIPTION
ORE v16 force you to send in a discount curve in base currency to generate flows.csv (in this [commit](https://github.com/Model-Validation/Engine/commit/680e1a28e1f424bd9f3d99bf0fcd79053d2848a5)). We could of course also change VL s.t. you always send in a base currency discount curve, but I guess that would need to be a hardcoded list per source per currency, or something.